### PR TITLE
Add Flumes AI – memory API for agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 ## 🧑‍💻 Coding Agents
 - **[Smol Developer](https://github.com/smol-ai/developer)**: Lightweight AI coding agent for rapid prototyping.
 - **[Aider](https://github.com/paul-gauthier/aider)**: AI coding agent for collaborative code editing and generation.
+- **[Flumes AI](https://www.flumes.ai)**: Unified memory infrastructure for AI agents. Store and retrieve facts, context, and prior outputs across sessions. SDK available, Langchain-compatible, with Colab demo and graph-based memory inspection.
 - **[GPT Engineer](https://github.com/AntonOsika/gpt-engineer)**: AI agent for building full applications from natural language.
 - **[DevOpsGPT](https://github.com/kuafuai/DevOpsGPT)**: AI agent for automating DevOps tasks and code integration.
 - **[Potpie](https://potpie.ai)**: AI coding agent for streamlined software development workflows.


### PR DESCRIPTION
Adds [Flumes AI](https://www.flumes.ai/), a persistent memory API for Langchain agents.
