### PR TITLE
docs: removes galileo.ai as it's acquired by google

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -305,7 +305,6 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[Kombai](https://kombai.com/)**: AI tool for converting designs into production-ready UI code.
 - **[Deepsite](https://huggingface.co/spaces/enzostvs/deepsite)**: An AI platform that helps you build stunning websites, no code required.
 - **[Rendition Create](https://www.renditioncreate.com/)**: AI-powered UI generator for web and mobile interfaces.
-- **[Galileo AI](https://www.usegalileo.ai/)**: AI platform for designing and prototyping user interfaces.
 - **[Phorm.ai](https://phorm.ai/)**: AI-powered form and interface generation.
 - **[Stitch (by Google)](https://stitch.withgoogle.com/)**: AI-powered UI generator from Google Labs, uses Gemini models to convert natural language or image inputs into multi-screen mobile/web UI designs and clean front‑end code; supports Figma export and conversational iteration.
 - **[Uizard](https://uizard.io/)**: AI-powered design tool converting hand-drawn mockups, screenshots, or text into interactive prototypes and code.


### PR DESCRIPTION
## 🚀 Summary

<!--
Describe the purpose of this PR. What addition or update are you making to the list?
-->
Galileo AI is acquired by Google and merged to Stitch by Google which is already included in this list ([link to Galileo AI's X](https://x.com/arnaudai/status/1924942577545195982))

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

<!--
Briefly explain why this tool deserves to be listed. What makes it unique or valuable for developers?
-->

## 🔗 Link

<!--
Paste the link you are adding (ensure it's live and accessible)
-->

## 📝 Additional context

<!--
Optional: anything else we should know or consider?
-->

