### PR TITLE
Add PM Skills to AI Tools for Developers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[Fig](https://fig.io/)**: Terminal autocomplete and AI assistance tool for command-line productivity (now part of AWS).
 - **[Codeflash](https://www.codeflash.ai/)**: Ship Blazing-Fast Python Code — Every Time. `#freemium`
 - **[Echo](https://echo.merit.systems/)**: Open-source Billing and Auth solution. Build AI apps and earn profit on every token your users generate with easy to use templates. 5 line change from the Vercel AI SDK. [#opensource](https://github.com/Merit-Systems/echo)
+- **[PM Skills](https://github.com/product-on-purpose/pm-skills)**: Open-source library of 24 product management agent skills for Claude Code, Codex, and other coding agents, following the agentskills.io specification.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [PM Skills](https://github.com/product-on-purpose/pm-skills) to the AI Tools for Developers section.

**What it is:**
- Open-source library of 24 product management agent skills across 6 Triple Diamond phases
- Works with Claude Code, Codex, and other coding agents
- Follows the [agentskills.io specification](https://agentskills.io/specification)
- Apache 2.0 licensed