### PR TITLE
Add Parallel Code to AI tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[Neurolink](https://github.com/juspay/neurolink)**: Open-source TypeScript SDK unifying 13 major AI providers and 100+ models through a single API with MCP support and multi-agent orchestration.
 - **[Mantra](https://mantra.gonewx.com)**: AI coding session management. Save, restore, and time-travel through your Claude Code, Cursor, and Windsurf sessions.
 - **[Syntropic](https://github.com/petercholford-ship-it/syntropic-cli)**: CLI tool (`npx syntropic init`) that scaffolds a structured development methodology into AI coding tool instruction files for Claude Code, Cursor, Windsurf, GitHub Copilot, and Codex. Free, MIT, zero dependencies.
-- [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app that runs multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) in parallel with automatic git worktree isolation, a unified GUI, and remote monitoring.
+- **[Parallel Code](https://github.com/johannesjo/parallel-code)**: Desktop app that runs multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) in parallel with automatic git worktree isolation, a unified GUI, and remote monitoring.
 
 ---
 


### PR DESCRIPTION
Added Parallel Code to the list of AI tools in the readme.

## 🚀 Summary

Parallel Code gives Claude Code, Codex CLI, and Gemini CLI each their own git branch and worktree – automatically. No agents stepping on each other's code, no juggling terminals, no mental overhead. Just one clean interface where you can see everything, navigate fast, merge results when they're ready – and monitor it all from your phone.


## ✅ Checklist

- [x ] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x ] The tool is **AI-related and useful for developers**
- [ x] I have **added a short, clear description** of the tool
- [ x] The link is not a **duplicate** of an existing one
- [ x] The title of the link is **properly capitalized**
- [ x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [ x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

Its ui makes multitasking different cli agents much easier and less overwhelming.

## 🔗 Link

https://github.com/johannesjo/parallel-code

