### PR TITLE
Add BGPT MCP to MCP Server/Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -412,6 +412,11 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 ---
 
 ## 🗄️ MCP Server/Tools
+
+### Individual MCP Servers
+- **[BGPT MCP](https://github.com/connerlambden/bgpt-mcp)** – Search scientific papers and get structured experimental data (methods, results, sample sizes, quality scores) from full-text studies. Remote MCP server, free tier with 50 searches.
+
+### MCP Directories
 - **[MCP Server Finder](https://www.mcpserverfinder.com/servers)**: Discover and browse a wide range of MCP servers.
 - **[MCP So](https://mcp.so/)**: Platform for MCP server resources and community.
 - **[MCP Market](https://mcpmarket.com/)**: Marketplace for MCP-related tools and services.


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) as an individual MCP server under the MCP Server/Tools section.

BGPT is a remote MCP server for searching scientific papers that returns structured experimental data from full-text studies. Free tier with 50 searches, no API key needed. Listed in the Official MCP Registry.

Also reorganized the section with "Individual MCP Servers" and "MCP Directories" subsections for clarity.