### PR TITLE
Add OpenPaw to Shell & CLI Assistants

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[GitHub Copilot CLI](https://github.com/cli/cli/tree/trunk/pkg/cmd/copilot)**: Official GitHub AI assistant for command-line with context-aware command suggestions.
 - **[ShellGPT](https://github.com/TheR1D/shell_gpt)**: Command-line tool integrating ChatGPT for shell command generation and system administration.
 - **[AICommits](https://github.com/Nutlope/aicommits)**: AI-powered tool for generating meaningful Git commit messages based on code changes.
+- **[OpenPaw](https://github.com/daxaur/openpaw)**: Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 built-in skills covering Telegram, Discord, Obsidian, daily briefings, and more.
 
 ---
 


### PR DESCRIPTION
Hi! Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Shell & CLI Assistants section.

OpenPaw is an open-source CLI tool (`npx pawmode`) that extends Claude Code with 38 built-in skills — things like Telegram/Discord messaging, Obsidian integration, daily briefings, and more. MIT licensed.

Thanks for maintaining this list!