### PR TITLE
Add PitchDocs to Documentation Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,443 @@
-placeholder
+# Awesome AI Coding Tools
+
+[![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+💡 Curated list of **AI-powered coding tools**: AI code editors, code completion engines, review assistants, refactoring agents, LLMs for developers, and tools that turn natural language into code.
+Ideal for developers, teams, researchers, and tech enthusiasts looking to leverage artificial intelligence in their software engineering workflows.
+
+
+> 🛠️ Contributions welcome – [Open a PR](https://github.com/ai-for-developers/awesome-ai-coding-tools/pulls).
+
+---
+
+## 📚 Table of Contents
+
+* [🌟 AI Code Assistants & Editors](#-ai-code-assistants--editors)
+* [🛠️ AI App Builders](#%EF%B8%8F-ai-app-builders)
+* [✨ AI Tools for Developers](#-ai-tools-for-developers)
+* [✍️ AI Code Completion](#️-ai-code-completion)
+* [🧠 Code Search & Navigation](#-code-search--navigation)
+* [🛠️ Code Review & Refactoring](#️-code-review--refactoring)
+* [📦 LLM Code Models](#-llm-code-models)
+* [⚙️ Natural Language to Code Tools](#️-natural-language-to-code-tools)
+* [💻 Shell & CLI Assistants](#-shell--cli-assistants)
+* [🧑‍💻 Coding Agents](#-coding-agents)
+* [🔄 PR Review Agents](#-pr-review-agents)
+* [🧪 Testing & QA Tools](#-testing--qa-tools)
+* [🧰 App Generators](#-app-generators)
+* [🎨 UI Generators](#-ui-generators)
+* [🔎 Snippet & Regex Tools](#-snippet--regex-tools)
+* [📖 Documentation Tools](#-documentation-tools)
+* [🔌 ChatGPT in Your Editor](#-chatgpt-in-your-editor)
+* [🚀 DevOps & Infrastructure](#-devops--infrastructure)
+* [🔒 Security & Compliance](#-security--compliance)
+* [🛡️ AI Security Tools](#️-ai-security-tools)
+* [📱 Mobile Development](#-mobile-development)
+* [🗄️ Database & API Tools](#️-database--api-tools)
+* [🎯 MLOps & Specialized Tools](#-mlops--specialized-tools)
+* [🗄️ MCP Server/Tools](#-mcp-server-tools)
+* [📚 Related Lists](#-related-lists)
+
+
+---
+
+
+## 🌟 AI Code Assistants & Editors
+- **[Cursor](https://www.cursor.sh/)**: AI-powered code editor with advanced autocompletion and real-time coding assistance.
+- **[Cody (Sourcegraph)](https://about.sourcegraph.com/cody)**: AI assistant for code understanding, navigation, and generation across repositories.
+- **[Windsurf](https://windsurf.com/)**: AI-powered code editor with a powerful and advanced flexible coding agent that goes beyond simple autocompletion and code generation.
+- **[Aider](https://aider.chat)**: Collaborative AI tool for pair-programming and generating code edits via CLI.
+- **[Phind](https://www.phind.com/)**: AI search and coding assistant for instant answers and code solutions.
+- **[Kilo Code](https://kilocode.ai)**: AI-enhanced coding tool for generating and optimizing code workflows.
+- **[Memex](https://memex.tech/)**: AI assistant for contextual code insights and personalized developer support.
+- **[ZZZ Code AI](https://zzzcode.ai)**: AI tool for code generation, debugging, and developer query resolution.
+- **[Trae](https://www.trae.ai/)**: An adaptive AI IDE that helps you code faster and collaborate with AI.
+- **[StackSpot AI](https://ai.stackspot.com/)**: AI platform for enterprise-grade code generation and developer efficiency.
+- **[Blackbox AI](https://www.blackbox.ai/)**: AI-driven coding assistant enhancing productivity with intelligent code completions and documentation.
+- **[Supermaven](https://supermaven.com/)**: Extremely fast AI code completion with low latency responses.
+- **[AskCodi](https://www.askcodi.com/)**: AI coding assistant with premium features for enhanced capabilities.
+- **[Tabby](https://tabby.tabbyml.com/)**: Self-hosted AI coding assistant with local deployment options.
+- **[Melty](https://melty.sh/)**: AI-powered development environment with intelligent assistance.
+- **[Void Editor](https://voideditor.com/)**: Minimalist code editor with AI integration.
+- **[Codel](https://codel.ai/)**: AI-powered development environment.
+- **[PearAI](https://pear.ai/)**: AI-powered development assistant.
+- **[Kiro](https://kiro.dev/)**: AI-powered development environment.
+- **[Zed](https://zed.dev/)** – High-performance, multiplayer code editor built in Rust with integrated AI assistance.
+- **[Claude Desktop](https://claude.ai/desktop)**: Anthropic's desktop application for development tasks, code analysis, and programming assistance.
+- **[Magic](https://magic.dev/)**: AI software engineer platform that understands codebases and handles complex development tasks autonomously.
+- **[Jupyter AI](https://jupyter-ai.readthedocs.io/)**: AI-powered extensions for Jupyter notebooks enabling natural language code generation and data analysis.
+- **[Replit Agent](https://replit.com/agent)**: Advanced AI agent within Replit that builds complete applications from natural language descriptions.
+- **[Devin AI](https://devin.ai/)**: An autonomous AI software engineer that can plan, code, debug, and deploy projects end-to-end.
+- **[Qoder](https://qoder.com/)**: Agentic Coding Platform for Real Software Think Deeper. Build Better.
+
+
+---
+
+## 🛠️ [AI App Builders](https://aifordevelopers.org/category/ai-app-builders)
+
+- **[Bolt.new](https://aifordevelopers.org/tool/bolt.new)** - [🔗](https://bolt.new/?utm_source=aifordevelopers.org&utm_medium=directory&utm_campaign=aifordevelopers) - AI-powered platform for building, editing, and deploying full-stack web applications directly in the browser using natural language prompts, with one-click Netlify deployment and support for frameworks like React and Next.js.
+- **[Dyad.sh](https://aifordevelopers.org/tool/dyad)** - [🔗](https://www.dyad.sh/?utm_source=aifordevelopers.org&utm_medium=directory&utm_campaign=aifordevelopers) - Free, local, open-source AI app builder running on your machine, offering flexibility with any AI model (e.g., Gemini, Claude) and seamless integration with IDEs like VS Code or Cursor, with Supabase support for backend features.
+- **[Lovable](https://aifordevelopers.org/tool/lovable)** - [🔗](https://lovable.dev/?utm_source=aifordevelopers.org&utm_medium=directory&utm_campaign=aifordevelopers) - AI-driven tool that enables users to create and deploy web applications from a single prompt in a browser tab.
+- **[Capacity](https://capacity.so/)**: Agentic coding platform leveraging Claude Code to transform ideas into full-stack web applications with minimal user input.
+- **[Builder.ai](https://www.builder.ai/)**: AI-driven custom software development platform that automates app creation for web and mobile, tailored to business needs.
+- **[10Web](https://10web.io/)**: AI-powered WordPress website builder with automated design, content generation, and optimization features for rapid app development.
+- **[Durable](https://durable.co/)**: AI website and business application builder that creates complete solutions, including backend and frontend, from simple text prompts.
+- **[Rocket.new](https://rocket.new/)**: AI-powered platform for rapid application development, focusing on generating scalable apps from natural language inputs.
+- **[base44](https://www.base44.com/)**: AI-native software development OS designed for startups to design, develop, and deploy products faster with integrated AI workflows.
+- **[MagicLoops](https://magicloops.dev)**: No-code platform that uses AI to create complete applications in minutes from text-based instructions.
+- **[Create.xyz](https://create.xyz/)**: AI-powered app creation platform that simplifies building web and mobile applications with automated code generation.
+- **[Mage](https://usemage.ai/)**: AI-powered platform for generating full-stack applications from natural language prompts, supporting rapid prototyping and deployment.
+
+---
+
+## ✨ AI Tools for Developers
+- **[Supercode.sh](https://supercode.sh/)**: Cursor extension that upgrades AI agent in Cursor with Architect Mode, precise voice input, prompt enhancement, etc.
+- **[SpecStory](https://specstory.com/)**: Cursor / VS Code / Claude Code extension for summarizing context across chats with AI and preserving / sharing tasks intents.
+- **[Task Master](https://github.com/eyaltoledano/claude-task-master)**: A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI.
+- **[Memory Bank](https://github.com/vanzan01/cursor-memory-bank)**: A token-optimized, hierarchical task management system that integrates with Cursor for efficient multi-step development workflows.
+- **[Context7](https://context7.com/)**: MCP server with up-to-date documentation for LLMs and AI code editors with precise token-usage management.
+- **[Raycast AI](https://raycast.com/ai)**: AI-powered productivity launcher with coding capabilities and developer workflow automation.
+- **[Perplexity Pro](https://perplexity.ai/pro)**: AI-powered search engine with real-time web access for coding solutions and documentation.
+- **[Warp AI](https://warp.dev/ai)**: AI-enhanced terminal with intelligent command suggestions and workflow optimization.
+- **[Fig](https://fig.io/)**: Terminal autocomplete and AI assistance tool for command-line productivity (now part of AWS).
+- **[Codeflash](https://www.codeflash.ai/)**: Ship Blazing-Fast Python Code — Every Time. `#freemium`
+- **[Echo](https://echo.merit.systems/)**: Open-source Billing and Auth solution. Build AI apps and earn profit on every token your users generate with easy to use templates. 5 line change from the Vercel AI SDK. [#opensource](https://github.com/Merit-Systems/echo)
+
+---
+
+## ✍️ AI Code Completion
+- **[GitHub Copilot](https://github.com/features/copilot)**: AI-driven code completion tool for real-time suggestions in IDEs.
+- **[Codeium](https://www.codeium.com/)**: AI-powered code autocompletion for multiple languages and IDEs.
+- **[Tabnine](https://www.tabnine.com/)**: AI code completion with deep learning for personalized suggestions.
+- **[JetBrains AI](https://www.jetbrains.com/ai/)**: Integrated AI for code completion and analysis in JetBrains IDEs.
+- **[Cascade](https://windsurf.com/)**: Windsurf's powerful coding agent as a code editor and IDE extension.
+- **[Refact.ai](https://refact.ai/)**: AI-powered code completion and refactoring for optimized development.
+- **[Replit Ghostwriter](https://replit.com/site/ghostwriter)**: AI code completion for fast prototyping in Replit's environment.
+- **[Google Code Assist (Gemini)](https://codeassist.google)**: AI-driven coding assistant for Google Cloud developers.
+- **[Continue](https://continue.dev/)**: Open-source AI tool for code completion and IDE integration.
+- **[Amazon Q Developer](https://aws.amazon.com/q/developer/)**: AI assistant for code completion, debugging, and AWS integration.
+- **[Visual Studio IntelliCode](https://visualstudio.microsoft.com/services/intellicode/)**: Microsoft's AI-powered code completion for Visual Studio ecosystem.
+- **[CodeGeeX](https://codegeex.cn/)**: Multilingual code generation model supporting multiple programming languages.
+- **[Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/)**: Real-time AI code suggestions with security vulnerability scanning and enterprise privacy controls.
+
+---
+
+## 🧠 Code Search & Navigation
+- **[Sourcegraph Cody](https://about.sourcegraph.com/cody)**: AI-powered code search and navigation for large codebases.
+- **[Wizi](https://github.com/wizi-ai/code-search)**: AI-driven code search tool for efficient repository exploration.
+- **[Cosine](https://ai.cosine.sh/)**: AI-powered code search and understanding for developer productivity.
+- **[Blinky Debugging Agent](https://github.com/seahyinghang8/blinky)**: AI agent for debugging and navigating code issues.
+- **[16x Prompt](https://prompt.16x.engineer/)**: AI tool for enhanced code search and prompt-based navigation.
+- **[Pieces.app](https://pieces.app/)**: AI-powered code snippet management and sharing.
+
+---
+
+## 🛠️ Code Review & Refactoring
+- **[CodeReviewBot](https://codereviewbot.ai)**: AI bot for automated code reviews and quality assurance.
+- **[JetBrains Qodana](https://www.jetbrains.com/qodana/)**: AI-powered static analysis for code quality and refactoring.
+- **[Amazon Q Developer Review Agent](https://aws.amazon.com/q/developer/)**: AI tool for automated code reviews in AWS projects.
+- **[Refact.ai](https://refact.ai/)**: AI-driven refactoring and code optimization for cleaner codebases.
+- **[Codiga](https://www.codiga.io/)**: AI-powered static code analysis for security and quality checks.
+- **[DeepCode](https://www.deepcode.ai/)**: AI-based code review tool for detecting bugs and vulnerabilities.
+- **[ReSharper](https://www.jetbrains.com/resharper/)**: AI-enhanced refactoring and code quality tool for .NET developers.
+- **[Qodo (CodiumAI)](https://www.qodo.ai/)**: Comprehensive code review and automated test generation platform.
+- **[Sourcery](https://sourcery.ai/)**: AI code reviewer supporting 30+ languages with actionable feedback.
+- **[Amazon CodeGuru Reviewer](https://aws.amazon.com/codeguru/)**: ML-powered code reviews with AWS integration.
+- **[DeepSource](https://deepsource.io/)**: Automated code review with technical debt tracking and security analysis.
+- **[Codacy](https://www.codacy.com/)**: Comprehensive code quality platform with 30+ language support.
+- **[Snyk (DeepCode)](https://snyk.io/)**: Security-focused code analysis with vulnerability detection.
+- **[Semgrep](https://semgrep.dev/)**: Static analysis tool for finding bugs and security issues.
+- **[CodeQL (GitHub)](https://codeql.github.com/)**: Semantic code analysis for security and quality.
+- **[ESLint](https://eslint.org/)**: JavaScript linting tool with AI-enhanced capabilities.
+- **[ReviewNB](https://www.reviewnb.com/)**: Jupyter notebook code review tool.
+- **[CodeAnt AI](https://codeant.ai/)**: AI-powered code review and quality analysis.
+- **[Squire.ai](https://squire.ai/)**: AI-powered code review and quality assurance.
+- **[Terragon](https://www.terragonlabs.com/dashboard)**: Comprehensive code review and automated test generation platform.
+- **[Embold](https://embold.io/)**: AI-powered code analysis focusing on code quality, maintainability, and technical debt identification.
+- **[PullRequest](https://www.pullrequest.com/)**: Human-AI hybrid code review service combining automated analysis with expert human reviewers.
+- **[Veracode](https://www.veracode.com/)**: AI-driven application security platform with static and dynamic analysis capabilities.
+- **[Gito](https://github.com/Nayjest/Gito)**: Open-source AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+
+---
+
+## 📦 LLM Code Models
+- **[Salesforce CodeGen](https://github.com/salesforce/CodeGen)**: Open-source LLM for generating high-quality code.
+- **[StarCoder](https://huggingface.co/bigcode/starcoder)**: Open-source LLM for code generation and programming tasks.
+- **[Code Llama](https://github.com/facebookresearch/codellama)**: Meta AI’s LLM optimized for code generation and completion.
+- **[Phi-3 Code](https://www.microsoft.com/en-us/research/blog/phi-3/)**: Microsoft’s lightweight LLM for efficient code generation.
+- **[Codestral](https://mistral.ai/news/codestral)**: Codestral is an open-weight generative AI model explicitly designed for code generation tasks.
+
+---
+
+## ⚙️ Natural Language to Code Tools
+- **[Parsel](https://github.com/ezelikman/parsel)**: Converts natural language descriptions into structured code.
+- **[Vibe Compiler](https://github.com/Strawberry-Computer/vibe-compiler)**: AI tool for translating natural language into executable code.
+- **[Plandex](https://github.com/plandex-ai/plandex)**: AI-driven tool for planning and generating code from text prompts.
+- **[Autodoc](https://github.com/context-labs/autodoc)**: AI-powered tool for generating code from natural language specifications.
+- **[ToolHive](https://github.com/stacklok/toolhive)**: AI platform for converting natural language into tool-specific code.
+- **[Lovable (GPT Engineer)](https://lovable.dev/)**: Natural language to app generation platform.
+- **[Marblism](https://marblism.com/)**: AI-powered full-stack application generation.
+- **[Pythagora.ai](https://pythagora.ai/)**: AI-powered full-stack development platform.
+- **[DataPup](https://github.com/DataPupOrg/DataPup)**: AI-powered Database client for generating context based SQL queries from natural language.
+
+---
+
+## 💻 Shell & CLI Assistants
+- **[OpenAI Codex](https://openai.com/blog/openai-codex/)**: OpenAI's CLI coding agent.
+- **[Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html)**: AI-powered CLI for AWS-related coding and scripting.
+- **[talk-codebase](https://github.com/rsaryev/talk-codebase)**: AI tool for querying and interacting with codebases via CLI.
+- **[poorcoder](https://github.com/vgrichina/poorcoder)**: Minimalist AI CLI tool for generating shell scripts and commands.
+- **[cmd-ai](https://github.com/BrodaNoel/cmd-ai)**: AI-driven CLI assistant for generating and optimizing shell commands.
+- **[Shell Whiz](https://github.com/beimzhan/shell-whiz)**: AI-powered shell assistant for automating command-line tasks.
+- **[Butterfish](https://butterfi.sh)**: AI tool for enhancing shell productivity with natural language.
+- **[TmuxAI](https://tmuxai.dev/)**: AI assistant for automating and optimizing tmux workflows.
+- **[Warp](https://www.warp.dev/)**: AI-enhanced terminal with smart command suggestions and workflows.
+- **[Codename Goose](https://github.com/block/goose)**: codename goose is a desktop and CLI tool that automates your tasks using large language models (LLMs) and extensions.
+- **[Mentat](https://mentat.ai/)**: AI coding assistant for command-line development.
+- **[Bito.ai](https://bito.ai/)**: AI-powered development assistant with CLI integration.
+- **[Opencode_CLI](https://github.com/opencode-ai/opencode)**: AI-powered development assistant with CLI integration.
+- **[GitHub Copilot CLI](https://github.com/cli/cli/tree/trunk/pkg/cmd/copilot)**: Official GitHub AI assistant for command-line with context-aware command suggestions.
+- **[ShellGPT](https://github.com/TheR1D/shell_gpt)**: Command-line tool integrating ChatGPT for shell command generation and system administration.
+- **[AICommits](https://github.com/Nutlope/aicommits)**: AI-powered tool for generating meaningful Git commit messages based on code changes.
+
+---
+
+## 🧑‍💻 Coding Agents
+- **[Smol Developer](https://github.com/smol-ai/developer)**: Lightweight AI coding agent for rapid prototyping.
+- **[Aider](https://github.com/paul-gauthier/aider)**: AI coding agent for collaborative code editing and generation.
+- **[Flumes AI](https://www.flumes.ai)**: Unified memory infrastructure for AI agents. Store and retrieve facts, context, and prior outputs across sessions. SDK available, Langchain-compatible, with Colab demo and graph-based memory inspection.
+- **[GPT Engineer](https://github.com/AntonOsika/gpt-engineer)**: AI agent for building full applications from natural language.
+- **[DevOpsGPT](https://github.com/kuafuai/DevOpsGPT)**: AI agent for automating DevOps tasks and code integration.
+- **[Potpie](https://potpie.ai)**: AI coding agent for streamlined software development workflows.
+- **[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)**: Anthropic’s AI agent for code generation and developer support.
+- **[Rovo Dev](https://www.atlassian.com/blog/announcements/rovo-dev-command-line-interface)**: Atlassian's specialized coding agent for the terminal.
+- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**: Google's flexible coding agent for the terminal.
+- **[OpenHands (OpenDevin)](https://opendevin.ai/)**: Open-source AI software engineer for autonomous development.
+- **[Cline (Claude Dev)](https://github.com/cline/cline)**: VS Code extension for Claude integration with file system access.
+- **[Devon](https://devon.ai/)**: AI software engineer for autonomous coding tasks.
+- **[Auto-Dev](https://auto-dev.ai/)**: Automated development tool with AI assistance.
+- **[Maestro](https://maestro.ai/)**: AI-powered development orchestration tool.
+- **[Software Agent AI](https://softwareagent.ai/)**: Autonomous AI agents for software development tasks.
+- **[Goose](https://goose.ai/)**: AI-powered development automation.
+- **[Deebo](https://deebo.ai/)**: AI-powered development assistant.
+- **[JunieAI (JetBrains)](https://www.jetbrains.com/junieai/)**: AI coding agent that plans, writes, tests, and refactors code intelligently within JetBrains IDEs—empowering you to focus on high-level development while it handles routine tasks.
+- **[Fine](https://fine.dev/)**: AI software development agent that understands requirements, writes code, and iterates autonomously.
+- **[Factory](https://factory.ai/)**: AI-powered software development platform automating repetitive coding tasks and accelerating development cycles.
+- **[Pythagora](https://pythagora.ai/)**: AI agent that builds applications through conversational interaction, handling frontend and backend development.
+
+---
+
+## 🔄 PR Review Agents
+- **[Sweep](https://github.com/sweepai/sweep)**: AI-powered agent for automating pull request reviews and fixes.
+- **[Greptile](https://greptile.com/code-review-bot)**: AI bot for in-depth code review and pull request analysis.
+- **[CodeRabbit](https://coderabbit.ai/)**: AI-driven tool for fast, contextual pull request reviews.
+- **[What The Diff](https://whatthediff.ai/)**: AI tool for summarizing and analyzing code diffs in PRs.
+- **[Nova](https://www.trynova.ai/)**: AI-powered agent for automated code reviews and suggestions.
+- **[Pixee](https://pixee.ai)**: AI bot for security-focused pull request reviews and fixes.
+- **[Qodo PR Agent](https://github.com/qodo-ai/pr-agent)**: AI agent for enhancing PR reviews with actionable insights.
+
+---
+
+## 🧪 Testing & QA Tools
+- **[Checksum AI](https://checksum.ai)**: AI-driven tool for automated software testing and validation.
+- **[OctoMind](https://octomind.dev)**: AI-powered platform for end-to-end testing automation.
+- **[KushoAI](https://kusho.ai/)**: AI-driven API testing tool for comprehensive QA automation.
+- **[Test Gru](https://gru.ai/home#test-gru)**: AI-powered testing assistant for streamlined QA workflows.
+- **[Qodo](https://www.qodo.ai/)**: AI tool for generating tests and ensuring code quality.
+- **[Meticulous](https://www.meticulous.ai/)**: AI-driven tool for automated visual and functional testing.
+- **[TestRigor](https://testrigor.com/)**: Plain English test automation with generative AI and self-healing capabilities.
+- **[Mabl](https://www.mabl.com/)**: AI-native test automation platform with auto-healing and visual testing.
+- **[Applitools](https://applitools.com/)**: Visual AI testing platform with cross-browser support.
+- **[Rainforest QA](https://www.rainforestqa.com/)**: AI-assisted testing with crowd-sourced manual testing.
+- **[Autify](https://autify.com/)**: Self-healing test automation with visual regression testing.
+- **[Functionize](https://www.functionize.com/)**: Machine learning-powered testing with natural language processing.
+- **[Testsigma](https://testsigma.com/)**: AI-powered test automation platform with natural language test creation.
+- **[Katalon Studio](https://katalon.com/)**: Comprehensive test automation platform with AI features.
+- **[ACCELQ](https://www.accelq.com/)**: Codeless test automation with AI-powered test design.
+- **[Reflect](https://reflect.run/)**: No-code test automation with AI-powered maintenance.
+- **[QA.tech](https://qa.tech/)**: AI-powered quality assurance and testing.
+- **[Octomind](https://octomind.dev/)**: AI-powered end-to-end testing.
+- **[Testsprite](https://testsprite.com/)**: AI-powered testing automation.
+- **[DiffBlue Cover](https://www.diffblue.com/)**: AI-powered tool specifically for generating comprehensive unit tests for Java applications.
+- **[Testim](https://www.testim.io/)**: AI-powered end-to-end testing platform with self-healing test capabilities and smart locators.
+- **[Launchable](https://launchableinc.com/)**: AI-driven test optimization platform that predicts which tests to run based on code changes.
+- **[Parasoft](https://www.parasoft.com/)**: Comprehensive AI-enhanced software testing suite covering static analysis, unit testing, and API testing.
+- **[Codeflash](https://www.codeflash.ai/)**: Ship Blazing-Fast Python Code — Every Time. `#freemium`
+
+---
+
+## 🧰 App Generators
+- **[Mage](https://usemage.ai/)**: AI-powered tool for generating full-stack applications from prompts.
+- **[SoftGen](https://softgen.ai/)**: AI platform for rapid application development and prototyping.
+- **[Co.dev](https://www.co.dev/)**: AI-driven tool for generating scalable web and mobile apps.
+- **[Pico](https://picoapps.xyz/)**: AI-powered app generator for quick MVP creation.
+- **[Bolt.new](https://bolt.new)**: AI tool for building web apps from natural language prompts.
+- **[Lovable](https://lovable.dev/)**: AI-powered platform that lets you create and deploy apps from a single browser tab.
+- **[Capacity](https://capacity.so/)**: Agentic coding platform that uses Claude Code under the hood to turn anyone's idea into a full stack web app.
+- **[Shakespeare](https://shakespeare.diy)**: Open-source & decentralized AI tool for building web apps in the browser with natural language chat.
+- **[CreateLex](https://createlex.com)**: AI-powered plugin for Unreal Engine that lets developers generate Blueprints, C++ code, and node graphs using natural language — streamlining game and XR development directly in the editor.
+- **[Replit](https://replit.com/)**: Complete cloud-based development environment with AI assistance.
+- **[Microsoft Power Apps](https://powerapps.microsoft.com/)**: Enterprise low-code platform with AI-powered app generation.
+- **[Glide](https://www.glideapps.com/)**: No-code mobile app builder with AI features and template library.
+- **[Softr](https://www.softr.io/)**: No-code app builder with AI assistance for rapid development.
+- **[Quickbase](https://www.quickbase.com/)**: Low-code platform with AI-enhanced application development.
+- **[Create.xyz](https://create.xyz/)**: AI-powered app creation platform.
+- **[Builder.ai](https://www.builder.ai/)**: AI-driven custom software development platform.
+- **[FlutterFlow](https://flutterflow.io/)**: Visual app builder for Flutter with AI assistance.
+- **[Nowa](https://nowa.dev/)**: Hybrid development platform with real-time sync capabilities.
+- **[Databutton](https://databutton.com/)**: AI-powered app development platform.
+- **[Rocket.new](https://rocket.new/)**: AI-powered rapid application development.
+- **[Builder.io Fusion](https://www.builder.io/)**: AI-powered visual development platform.
+- **[Manifest.build](https://manifest.build/)**: AI-driven Backend.
+- **[lovable.dev](https://lovable.dev/)**:  It allows you to build and deploy web applications from a single prompt.
+- **[MagicLoops](https://magicloops.dev)**: Create complete apps in minutes with no code.
+- **[base44](https://www.base44.com/)**: AI-native software development OS for startups to design, develop & deploy products faster.
+- **[10Web](https://10web.io/)**: AI-powered WordPress website builder with automated design, content generation, and optimization features.
+- **[Framer AI](https://framer.com/ai)**: AI-powered website builder with advanced design capabilities and no-code/low-code approach.
+- **[Webflow AI](https://webflow.com/ai)**: AI features within Webflow for automated design assistance and content generation.
+- **[Durable](https://durable.co/)**: AI website and business application builder that creates complete business solutions from simple prompts.
+
+---
+
+## 🎨 UI Generators
+- **[v0.dev](https://v0.dev/)**: AI-powered tool for generating UI designs from text prompts.
+- **[Magic Patterns](https://www.magicpatterns.com/)**: AI-driven platform for creating reusable UI components.
+- **[Kombai](https://kombai.com/)**: AI tool for converting designs into production-ready UI code.
+- **[Deepsite](https://huggingface.co/spaces/enzostvs/deepsite)**: An AI platform that helps you build stunning websites, no code required.
+- **[Rendition Create](https://www.renditioncreate.com/)**: AI-powered UI generator for web and mobile interfaces.
+- **[Phorm.ai](https://phorm.ai/)**: AI-powered form and interface generation.
+- **[Stitch (by Google)](https://stitch.withgoogle.com/)**: AI-powered UI generator from Google Labs, uses Gemini models to convert natural language or image inputs into multi-screen mobile/web UI designs and clean front‑end code; supports Figma export and conversational iteration.
+- **[Uizard](https://uizard.io/)**: AI-powered design tool converting hand-drawn mockups, screenshots, or text into interactive prototypes and code.
+- **[Figma AI](https://figma.com/ai)**: Native AI features within Figma for automated design tasks, content generation, and design-to-code workflows.
+- **[TeleportHQ](https://teleporthq.io/)**: AI-powered front-end design platform generating production-ready code from visual designs.
+- **[Freepik](https://www.freepik.com/)**: AI-powered design platform with image generation, background removal, and mockup creation tools for UI designers and developers.
+---
+
+## 🔎 Snippet & Regex Tools
+- **[AutoRegex](https://www.autoregex.xyz/)**: AI-powered tool for generating and explaining regular expressions.
+- **[CodePal](https://codepal.ai/)**: AI assistant for generating code snippets and utilities.
+- **[AI Code Convert](https://aicodeconvert.com/)**: AI tool for converting code between programming languages.
+
+---
+
+## 📖 Documentation Tools
+- **[Trelent](https://trelent.net/)**: AI-powered tool for generating code documentation and comments.
+- **[README-AI](https://github.com/eli64s/readme-ai)**: AI tool for creating professional README files automatically.
+- **[PitchDocs](https://github.com/littlebearapps/pitchdocs)**: Claude Code plugin that generates marketing-ready repository documentation — README, CHANGELOG, CONTRIBUTING, AI context files, and 15+ more files with evidence-based feature extraction and quality scoring.
+- **[DocuWriter.ai](https://www.docuwriter.ai/)**: AI-driven documentation generator for codebases and APIs.
+- **[DiagramGPT](https://www.eraser.io/diagramgpt)**: AI tool for generating diagrams from code and text descriptions.
+- **[Supacodes](https://www.supacodes.com)**: AI-powered platform for automated code documentation.
+- **[Cleric.io](https://cleric.io/)**: AI assistant for technical documentation and code explanation.
+- **[Theneo.io](https://theneo.io/)**: AI-powered API documentation generation.
+- **[Mintlify](https://mintlify.com/)**: AI-powered documentation platform that automatically generates and maintains technical documentation from code.
+- **[GitBook AI](https://gitbook.com/ai)**: AI-enhanced documentation platform with intelligent content suggestions and automated organization.
+- **[Slab](https://slab.com/)**: Team knowledge base with AI-powered search, content suggestions, and automated documentation workflows.
+- **[GPTutor](https://gptutor.tools/)**: VS Code extension offering customizable LLM‑powered code explanations and tutoring across 120+ human languages and 50+ programming languages.
+
+---
+
+## 🔌 ChatGPT in Your Editor
+- **[CodeGPT.nvim](https://github.com/dpayne/CodeGPT.nvim)**: Neovim plugin for integrating ChatGPT-powered code assistance.
+- **[autocomplete.sh](https://github.com/closedLoop-technologies/autocomplete-sh)**: AI-powered shell autocompletion using ChatGPT.
+- **[org-ai (Emacs)](https://github.com/rksm/org-ai)**: Emacs plugin for ChatGPT-based coding and text assistance.
+- **[Genie AI – ChatGPT for VS Code](https://github.com/ai-genie/chatgpt-vscode)**: VS Code extension for ChatGPT-powered coding support.
+- **[Alexsidebar](https://alexsidebar.com/)**: AI-powered development assistant.
+
+---
+
+## 🚀 DevOps & Infrastructure
+- **[Datadog](https://www.datadoghq.com/)**: Comprehensive monitoring and observability platform with AI-powered insights.
+- **[PagerDuty](https://www.pagerduty.com/)**: AI-powered incident management and response automation.
+- **[New Relic](https://newrelic.com/)**: Observability platform with AIOps capabilities and anomaly detection.
+- **[Spacelift](https://spacelift.io/)**: AI-powered infrastructure automation with policy as code.
+- **[Digital.ai](https://digital.ai/)**: End-to-end DevOps platform with AI-driven insights.
+- **[Sysdig](https://sysdig.com/)**: Cloud security and monitoring with AI-powered threat detection.
+- **[Jenkins X](https://jenkins-x.io/)**: Cloud-native CI/CD with AI-enhanced automation.
+- **[Opsera](https://www.opsera.io/)**: Unified DevOps platform with AI-powered workflow optimization.
+- **[LambdaTest](https://www.lambdatest.com/)**: AI-powered cross-browser testing platform.
+- **[MindStudio](https://mindstudio.ai/)**: AI agent creation and deployment platform for DevOps workflows.
+- **[CrewAI](https://www.crewai.com/)**: Multi-agent platform for automated DevOps workflows.
+- **[Kubiya.ai](https://kubiya.ai/)**: AI-powered DevOps automation platform.
+- **[Warestack](https://warestack.com/)**: AI-powered development infrastructure.
+- **[Harness](https://harness.io/)**: AI-powered CI/CD platform with intelligent deployment strategies, automated rollbacks, and performance optimization.
+- **[GitLab AI](https://about.gitlab.com/solutions/artificial-intelligence/)**: Integrated AI features across GitLab including code suggestions, security scanning, and workflow optimization.
+- **[Terraform Cloud](https://www.terraform.io/cloud)** – Infrastructure as code platform with AI-powered policy suggestions and optimization recommendations.
+- **[Pulumi AI](https://www.pulumi.com/ai/)**: Infrastructure as code platform with AI assistance for cloud resource management and optimization.
+
+---
+
+## 🔒 Security & Compliance
+- **[Nullify.ai](https://nullify.ai/)**: AI-powered security vulnerability detection.
+- **[Pixee.ai](https://pixee.ai/)**: Automated code security fixes with AI.
+- **[Gecko Security](https://gecko.security/)**: AI-powered security analysis for code.
+- **[Codegate](https://codegate.ai/)**: AI-powered code security and compliance.
+- **[Zeropath](https://zeropath.com/)**: AI-powered security testing.
+- **[Checkmarx](https://checkmarx.com/)**: AI-enhanced static application security testing platform with comprehensive vulnerability detection.
+- **[Mend (formerly WhiteSource)](https://www.mend.io/)**: AI-powered open source security and license compliance platform.
+- **[JFrog Xray](https://jfrog.com/xray/)**: AI-driven security and compliance scanning for DevOps pipelines and artifact repositories.
+
+---
+
+## 🛡️ AI Security Tools
+- **[Snyk Code AI](https://snyk.io/product/snyk-code/)**: Static Application Security Testing (SAST) tool for scanning source code for vulnerabilities and insecure patterns as you write, powered by DeepCode AI.
+- **[Snyk API & Web](https://snyk.io/product/api-security/)**: Dynamic Application Security Testing (DAST) tool for discovering and testing the security of running APIs and web applications using AI-driven analysis.
+- **Snyk DeepCode AI**: The AI engine that powers Snyk Code and other Snyk security tools, providing advanced vulnerability detection, autofix, and risk prioritization. (Not a standalone product)
+- **[GitGuardian AI](https://www.gitguardian.com/)**: AI-based tool that monitors codebases for leaked secrets, API keys, credentials, and sensitive information across both public and private repositories.
+- **[Bearer CLI](https://github.com/Bearer/bearer)**: Open-source AI tool for static security analysis, specializing in detecting sensitive data exposure and ensuring compliance with regulations like GDPR and PCI-DSS.
+- **[HackerOne Code](https://www.hackerone.com/product/code)**: Combines AI and human expertise for code security, offering context-aware vulnerability detection, triage, and remediation tailored for AI-generated and human-written code.
+- **[Endor Labs AI Code Security](https://www.endorlabs.com/ai-code-security-review)**: AI-driven code review platform that analyzes every pull request for security risks, architectural changes, and business logic vulnerabilities, with actionable insights and context.
+- **[Code Intelligence CI Fuzz](https://www.code-intelligence.com/)**: AI-automated fuzz testing tool for C/C++ and other languages, enabling developers to find and fix critical bugs and vulnerabilities early in the development process.
+
+---
+
+## 📱 Mobile Development
+- **[FlutterFlow AI](https://flutterflow.io/ai)**: AI-powered visual development platform for Flutter applications with drag-and-drop interface and code generation.
+- **[Thunkable](https://thunkable.com/)**: AI-assisted no-code mobile app development platform supporting both iOS and Android.
+- **[AppSheet (Google)](https://www.appsheet.com/)**: No-code app development platform with AI-powered data integration and workflow automation.
+
+---
+
+## 🗄️ Database & API Tools
+- **[Supabase AI](https://supabase.com/ai)**: AI features for database schema generation, query optimization, and API development assistance.
+- **[Hasura](https://hasura.io/)**: GraphQL API platform with AI-powered query optimization and schema management.
+- **[Retool AI](https://retool.com/ai)**: AI-powered internal tool builder with natural language interface for creating business applications.
+
+---
+
+## 🎯 MLOps & Specialized Tools
+- **[Weights & Biases](https://wandb.ai/)** – MLOps platform with AI model management, experiment tracking, and automated hyperparameter optimization.
+- **[Gradio](https://gradio.app/)** – AI tool for rapidly creating machine learning model demos and interactive interfaces.
+- **[Streamlit](https://streamlit.io/)** – Framework for building AI/ML data applications with minimal code and AI-powered features.
+- **[Observable](https://observablehq.com/)** – Data visualization platform with AI-enhanced analysis and interactive notebook capabilities.
+
+---
+
+## 🗄️ MCP Server/Tools
+- **[MCP Server Finder](https://www.mcpserverfinder.com/servers)**: Discover and browse a wide range of MCP servers.
+- **[MCP So](https://mcp.so/)**: Platform for MCP server resources and community.
+- **[MCP Market](https://mcpmarket.com/)**: Marketplace for MCP-related tools and services.
+- **[Cursor MCP Directory](https://cursor.directory/mcp)**: Directory of MCP servers and tools curated by Cursor.
+- **[VSCode MCP Directory](https://code.visualstudio.com/mcp)**: Official VSCode directory for MCP servers and integrations.
+- **[Claude MCP Servers](https://www.claudemcp.com/servers)**: Claude's curated list of MCP servers.
+- **[PulseMCP Server Directory](https://www.pulsemcp.com/servers)**: Large, frequently updated directory of MCP servers, including trending, official, and community servers across many categories.
+- **[MCPServers.Net](https://mcpservers.net/)**: Comprehensive MCP server navigation platform, featuring official and community servers, tutorials, and resources.
+
+---
+
+## 📚 Related Lists
+
+- **[AI For Developers](https://aifordevelopers.org)**: Curated list of AI Devtools  for various applications.
+- **[Awesome Vibe Coding](https://github.com/ai-for-developers/awesome-vibe-coding)**: A hand-picked collection of tools and resources for Vibe Coding
+- **[Awesome AI Tools](https://github.com/mahseema/awesome-ai-tools)**: Curated list of general AI tools for various applications.
+- **[Awesome AI Agents](https://github.com/aylar-ghezelbash/awesome-ai-agents)**: Collection of AI agents for automation and development tasks.
+- **[Awesome Content Marketing](https://github.com/marketinguys/awesome-content-marketing)**
+- **[Altern](https://altern.ai)**: Find Almost anything related to AI
+- **[DevTools Directory](https://devtools.directory)**: Directory of trending Dev Tools
+- **[Awesome AI Newsletters](https://github.com/alternbits/awesome-ai-newsletters)**: A curated list of top best AI Related Newsletters
+- **[Best Of AI](https://github.com/best-of-ai/best-of-ai)**: A curated list of best ai tools
+- **[Awesome AI Models](https://github.com/alternbits/awesome-ai-models)**: A curated list of top AI models and LLMs
+- **[Awesome AI Marketing](https://github.com/alternbits/awesome-ai-marketing)**: A curated list of top best ai tools for marketing
+- **[Awesome Developer Marketing](https://github.com/marketinguys/awesome-dev-marketing)**
+- **[Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)**: A curated list of awesome marketing tools and resources
+- **[Awesome Productivity](https://github.com/ProductivityDirectory/awesome-productivity-tools)**: Awesome list of productivity tools and products
+


### PR DESCRIPTION
Adds [PitchDocs](https://github.com/littlebearapps/pitchdocs) to the Documentation Tools section — a Claude Code plugin that generates professional, marketing-ready repository documentation.\n\nGenerates README, CHANGELOG, CONTRIBUTING, ROADMAP, AI context files, user guides, and 15+ more files from slash commands with evidence-based feature extraction and quality scoring (0–100). 100% Markdown, zero runtime dependencies, MIT licensed.