### PR TITLE
Add Skillfold to Coding Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[Fine](https://fine.dev/)**: AI software development agent that understands requirements, writes code, and iterates autonomously.
 - **[Factory](https://factory.ai/)**: AI-powered software development platform automating repetitive coding tasks and accelerating development cycles.
 - **[Pythagora](https://pythagora.ai/)**: AI agent that builds applications through conversational interaction, handling frontend and backend development.
+- **[Skillfold](https://github.com/byronxlg/skillfold)**: Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into agent skills for 11 platforms including Claude Code, Cursor, and Codex.
 
 ---
 


### PR DESCRIPTION
Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Coding Agents section.

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles YAML config into agent skills for 11 platforms including Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Copilot, Goose, Roo Code, Kiro, Junie, and Agent Teams.

- Open source (MIT)
- Published on npm
- Well-documented with getting-started guide and VitePress docs site