### PR TITLE
Add Den to DevOps & Infrastructure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,6 +362,7 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 - **[GitLab AI](https://about.gitlab.com/solutions/artificial-intelligence/)**: Integrated AI features across GitLab including code suggestions, security scanning, and workflow optimization.
 - **[Terraform Cloud](https://www.terraform.io/cloud)** – Infrastructure as code platform with AI-powered policy suggestions and optimization recommendations.
 - **[Pulumi AI](https://www.pulumi.com/ai/)**: Infrastructure as code platform with AI assistance for cloud resource management and optimization.
+- **[Den](https://github.com/us/den)**: Self-hosted sandbox runtime for AI coding agents with secure Docker-based code execution, MCP server, REST API, and Go/TypeScript/Python SDKs.
 
 ---
 


### PR DESCRIPTION
Add [Den](https://github.com/us/den) — a self-hosted sandbox runtime for AI coding agents — to the DevOps & Infrastructure section.

Den provides secure code execution in Docker containers with an MCP server, REST API, and SDKs for Go, TypeScript, and Python.