### PR TITLE
Add brood-box to Coding Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AutoGen](https://github.com/microsoft/autogen)** – Microsoft's multi-agent framework for building AI agent teams that collaborate on coding tasks.
 - **[CrewAI](https://www.crewai.com/)** – Multi-agent orchestration platform for building teams of AI agents for development and automation.
 - **[Copilot Workspace](https://githubnext.com/projects/copilot-workspace)** – GitHub's agent-powered dev environment that turns issues into code changes with plans, specs, and implementation.
+- **[brood-box](https://github.com/stacklok/brood-box)** – Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization.
 
 ---
 


### PR DESCRIPTION
## Summary

Add [brood-box](https://github.com/stacklok/brood-box) to the **Coding Agents** section.

brood-box is a CLI tool for running coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs. It provides snapshot isolation, DNS-aware egress control, and MCP authorization profiles so that AI agents operate in a sandboxed environment with minimal blast radius.

- Open source (Apache-2.0), publicly accessible on GitHub
- AI-powered: wraps and sandboxes AI coding agents
- Useful to developers who want to run coding agents with strong security boundaries