### PR TITLE
Add CronAI to Developer Productivity Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -273,6 +273,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Perplexity Pro](https://perplexity.ai/pro)** – AI search engine with real-time web access for coding solutions.
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.
 - **[Supercode.sh](https://supercode.sh/)** – Cursor extension adding Architect Mode, voice input, and prompt enhancement.
+- **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 
 ---
 


### PR DESCRIPTION
Adds [CronAI](https://cronai-nu.vercel.app/) — an AI tool that converts plain English schedule descriptions to cron expressions.

- Supports standard and extended cron formats
- Free, no signup required
- Added to end of Developer Productivity Tools section