### PR TITLE
Add Wiggum CLI to Coding Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AutoGen](https://github.com/microsoft/autogen)** – Microsoft's multi-agent framework for building AI agent teams that collaborate on coding tasks.
 - **[CrewAI](https://www.crewai.com/)** – Multi-agent orchestration platform for building teams of AI agents for development and automation.
 - **[Copilot Workspace](https://githubnext.com/projects/copilot-workspace)** – GitHub's agent-powered dev environment that turns issues into code changes with plans, specs, and implementation.
+- **[Wiggum CLI](https://wiggum.app)** – Open-source agent that scans codebases, generates specs through AI interviews, and runs autonomous coding loops via Claude Code or Codex. Agent mode ships GitHub issues end-to-end.
 
 ---
 


### PR DESCRIPTION
Adds [Wiggum CLI](https://wiggum.app) to the Coding Agents section.

Wiggum is an open-source AI agent CLI that scans codebases, generates feature specs through AI interviews, and runs autonomous coding loops via Claude Code or Codex. Its agent mode reads the GitHub backlog and ships issues end-to-end.

- GitHub: https://github.com/federiconeri/wiggum-cli
- Website: https://wiggum.app
- npm: https://www.npmjs.com/package/wiggum-cli

This is a clean resubmission of #77 — single line addition, no unrelated changes.