### PR TITLE
Add Forge to App Builders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Builder.io Fusion](https://www.builder.io/)** – AI-powered visual development platform.
 - **[Bolt.diy](https://github.com/stackblitz-labs/bolt.diy)** – Open-source fork of Bolt.new supporting any LLM (local or cloud) for building full-stack apps in the browser.
 - **[Screenshot-to-Code](https://github.com/abi/screenshot-to-code)** – Convert screenshots and designs into clean HTML/React/Vue code using AI.
+- **[Forge](https://forge-web.rebaselabs.online)** – BYOK full-stack app creator — use your own API key (Anthropic, OpenAI, Google) with no markup. Multi-stage pipeline generates production-ready Next.js apps from natural language.
 
 ---
 


### PR DESCRIPTION
Adds [Forge](https://forge-web.rebaselabs.online) to the App Builders section.

Forge is an AI-powered full-stack app creator with a BYOK (bring your own key) model — users provide their own Anthropic, OpenAI, or Google AI API key with no markup. It generates production-ready Next.js apps from natural language using a multi-stage pipeline (Planner → Architect → Coder → Verifier with auto-fix).

- **Website:** https://forge-web.rebaselabs.online
- **GitHub:** https://github.com/sudo-rebase/forge
- **Free tier:** Yes (BYOK — users pay only their own API costs)
- **AI-powered:** Yes — LLM-driven code generation pipeline
- **Developer-focused:** Generates TypeScript strict mode, SSR-first Next.js App Router apps

Added to the end of the App Builders section per contribution guidelines.