### PR TITLE
Add OpenASE to Coding Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AutoGen](https://github.com/microsoft/autogen)** – Microsoft's multi-agent framework for building AI agent teams that collaborate on coding tasks.
 - **[CrewAI](https://www.crewai.com/)** – Multi-agent orchestration platform for building teams of AI agents for development and automation.
 - **[Copilot Workspace](https://githubnext.com/projects/copilot-workspace)** – GitHub's agent-powered dev environment that turns issues into code changes with plans, specs, and implementation.
+- **[OpenASE](https://github.com/PacificStudio/openase)** – Open-source, ticket-driven software engineering platform that orchestrates Claude Code, Codex, and Gemini CLI agents across your machines with workflows, skills, and full traceability.
 
 ---
 


### PR DESCRIPTION
## What
Add OpenASE to the `Coding Agents` section.

## Why
OpenASE is an open-source AI software engineering platform focused on ticket-driven workflows. It orchestrates coding agents like Claude Code, Codex, and Gemini CLI to pick up tickets, execute workflows on user machines, and keep execution traceable.

It is:
- AI-powered and developer-focused
- publicly accessible
- free/open-source
- documented with a clear use case

## Validation
- Markdown-only change
- Verified the new entry follows the repository's contribution format and was added to the end of the relevant section

## Risk / Rollback
- Low risk; single-line documentation entry
- Revert the added list item if maintainers prefer a different section or wording
