### PR TITLE
Add toprank — SEO + Ads plugin for Claude Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -273,6 +273,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Perplexity Pro](https://perplexity.ai/pro)** – AI search engine with real-time web access for coding solutions.
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.
 - **[Supercode.sh](https://supercode.sh/)** – Cursor extension adding Architect Mode, voice input, and prompt enhancement.
+- **[toprank](https://github.com/nowork-studio/toprank)** – Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
 
 ---
 


### PR DESCRIPTION
Adds **toprank** under Developer Productivity Tools, alongside other AI editor extensions like SpecStory and Task Master.

toprank is an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes directly from Claude Code: meta tag rewrites, JSON-LD schema markup generation, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost.

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 100+ stars, actively maintained