### PR TITLE
Add codachi to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Mentat](https://mentat.ai/)** – AI coding assistant for command-line development.
 - **[TmuxAI](https://tmuxai.dev/)** – AI assistant for automating tmux workflows.
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
+- **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 
 ---
 


### PR DESCRIPTION
Adding codachi to the CLI Tools section — it's a context window monitor for Claude Code that sits in the statusline and shows burn rate + time-until-full, plus a small ASCII pet that changes mood based on what's happening (test results, git ops, etc.). Published on npm.

https://github.com/vincent-k2026/codachi