### PR TITLE
Add Helium MCP to MCP servers and directories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Claude MCP Servers](https://www.claudemcp.com/servers)** – Claude's curated MCP server list.
 - **[MCPServers.Net](https://mcpservers.net/)** – Comprehensive MCP navigation with tutorials and resources.
 - **[MCP Market](https://mcpmarket.com/)** – Marketplace for MCP tools and services.
+- **[Helium MCP](https://github.com/connerlambden/helium-mcp)** – Remote MCP server for AI coding assistants with real-time news and multi-dimensional bias scoring (3.2M+ articles, 5000+ sources), financial markets (stocks, ETFs, crypto, AI bull/bear cases), ML options pricing (ITM probability, Greeks, fair value), balanced news synthesis, trending topics, and semantic meme search. [Documentation](https://heliumtrades.com/mcp-page/).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **[Helium MCP](https://github.com/connerlambden/helium-mcp)** to the [MCP Servers and Directories](https://github.com/ai-for-developers/awesome-ai-coding-tools#mcp-servers-and-directories) section of `readme.md`, at the end of that section per the contribution guide.

## What is Helium MCP?

Helium MCP is a **remote MCP server** that connects AI coding assistants (Cursor, Claude Code, VS Code, and other MCP clients) to:

- **News intelligence** — Real-time coverage with bias scoring across 15+ dimensions, drawn from 3.2M+ articles and 5000+ sources  
- **Financial markets** — Stocks, ETFs, crypto, and AI-generated bull/bear cases  
- **ML options pricing** — Probability ITM, Greeks, fair value, and related analytics  
- **Balanced news synthesis** and **trending topics**  
- **Semantic meme search**

## Links

- **Repository:** https://github.com/connerlambden/helium-mcp  
- **Documentation:** https://heliumtrades.com/mcp-page/

## Checklist

- [x] Placed at the **end** of the appropriate section  
- [x] Uses the list format from CONTRIBUTING.md  
- [x] Tool is AI-related, developer-oriented, and publicly documented