### PR TITLE
Add MemClaw — persistent project memory MCP server for AI coding agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.
 - **[Supercode.sh](https://supercode.sh/)** – Cursor extension adding Architect Mode, voice input, and prompt enhancement.
 - **[toprank](https://github.com/nowork-studio/toprank)** – Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
+- **[MemClaw](https://memclaw.me)** – Persistent project memory for AI coding agents (MCP-compatible). Creates isolated memory workspaces per project with a web dashboard to review and manage context. Free and open source.
 
 ---
 


### PR DESCRIPTION
Adds **MemClaw** under Developer Productivity Tools, alongside Context7 and Task Master.

MemClaw is a persistent project memory MCP server for AI coding agents (Cursor, Claude Code, etc.). Unlike generic memory layers, it creates **isolated memory workspaces per project** so agents remember context without cross-project leakage. Includes a web dashboard for reviewing and managing what your AI remembers.

- Source: https://github.com/Felo-Inc/memclaw
- License: MIT
- Free to use