### PR TITLE
Add AI Dev Jobs MCP and Not Human Search to MCP Servers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,8 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Claude MCP Servers](https://www.claudemcp.com/servers)** – Claude's curated MCP server list.
 - **[MCPServers.Net](https://mcpservers.net/)** – Comprehensive MCP navigation with tutorials and resources.
 - **[MCP Market](https://mcpmarket.com/)** – Marketplace for MCP tools and services.
+- **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
+- **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 
 ---
 


### PR DESCRIPTION
## Summary

- **AI Dev Jobs MCP** — Search 5,400+ AI developer jobs with salary data via MCP. Also offers a REST API at aidevboard.com/docs.
- **Not Human Search** — Agent-first search engine for discovering AI tools, MCP servers, and APIs across 1,400+ indexed sites.

Both are publicly accessible with free, open access and well-documented APIs.