### PR TITLE
Add git-parsec to Developer Productivity Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -276,6 +276,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.
 - **[Supercode.sh](https://supercode.sh/)** – Cursor extension adding Architect Mode, voice input, and prompt enhancement.
 - **[toprank](https://github.com/nowork-studio/toprank)** – Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
+- **[git-parsec](https://github.com/erishforG/git-parsec)** – Git worktree lifecycle manager that gives each AI agent an isolated workspace tied to issue tickets (Jira, GitHub Issues, GitLab), avoiding index.lock conflicts in parallel workflows.
 
 ---
 


### PR DESCRIPTION
## What is git-parsec?

[git-parsec](https://github.com/erishforG/git-parsec) is a git worktree lifecycle manager built in Rust.

When multiple AI coding agents (Claude Code, Cursor, Aider, etc.) work on the same repository simultaneously, they collide on `.git/index.lock`. git-parsec solves this by giving each agent its own isolated worktree, tied to an issue ticket from Jira, GitHub Issues, or GitLab.

It handles the full lifecycle — create worktree from ticket ID, fetch ticket title, push + create PR, clean up — so agents (and developers) can focus on writing code instead of managing git state.

### Why Developer Productivity Tools?

git-parsec isn't an AI agent itself — it's infrastructure that makes AI agents more productive. It sits alongside tools like Git AI and Task Master in enabling better AI-assisted development workflows.

### Links

- Repository: https://github.com/erishforG/git-parsec
- Docs: https://erishforg.github.io/git-parsec/reference/