### PR TITLE
Add MeterCall to App Builders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Builder.io Fusion](https://www.builder.io/)** – AI-powered visual development platform.
 - **[Bolt.diy](https://github.com/stackblitz-labs/bolt.diy)** – Open-source fork of Bolt.new supporting any LLM (local or cloud) for building full-stack apps in the browser.
 - **[Screenshot-to-Code](https://github.com/abi/screenshot-to-code)** – Convert screenshots and designs into clean HTML/React/Vue code using AI.
+- **[MeterCall](https://metercall.ai)** – Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
 
 ---
 


### PR DESCRIPTION
Adding MeterCall — universal API gateway with AI router across 25+ models (Claude, GPT, Gemini, Llama, Groq, etc). Type a sentence, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.

Fits App Builders alongside Bolt.new, Lovable, Replit, v0.dev, Capacity. Difference is the 10M+ API gateway underneath that wires services together automatically. Thanks for maintaining this list.

— https://metercall.ai