### PR TITLE
Add CLIRank to MCP Servers and Directories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Claude MCP Servers](https://www.claudemcp.com/servers)** – Claude's curated MCP server list.
 - **[MCPServers.Net](https://mcpservers.net/)** – Comprehensive MCP navigation with tutorials and resources.
 - **[MCP Market](https://mcpmarket.com/)** – Marketplace for MCP tools and services.
+- **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
 
 ---
 


### PR DESCRIPTION
Adds [CLIRank](https://clirank.dev/) to the MCP Servers and Directories section.

CLIRank is an API directory scoring 387 APIs on agent-friendliness across 11 signals, available as both an MCP server (`clirank-mcp-server` on npm) and a web directory.