### PR TITLE
Add AgentsMesh to Coding Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AutoGen](https://github.com/microsoft/autogen)** – Microsoft's multi-agent framework for building AI agent teams that collaborate on coding tasks.
 - **[CrewAI](https://www.crewai.com/)** – Multi-agent orchestration platform for building teams of AI agents for development and automation.
 - **[Copilot Workspace](https://githubnext.com/projects/copilot-workspace)** – GitHub's agent-powered dev environment that turns issues into code changes with plans, specs, and implementation.
+- **[AgentsMesh](https://agentsmesh.ai)** – Self-hostable AI Agent Workforce Platform. Orchestrates Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode across remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, channels-based multi-agent collaboration, built-in Kanban, and per-pod MCP server. Multi-Git (GitHub/GitLab/Gitee), multi-tenant, SSO/RBAC, BYOK.
 
 ---
 


### PR DESCRIPTION
Adding [AgentsMesh](https://agentsmesh.ai) to **Coding Agents** section.

Fits alongside PraisonAI / CrewAI / AutoGen as a multi-agent orchestration platform:
- **AgentPods** — remote AI workstations with PTY sandbox + git worktree isolation
- **Multi-agent collaboration** via channels and pod bindings
- **Built-in Kanban** with ticket-pod binding and MR/PR integration
- **Per-pod MCP server** — Claude Code / Cursor integration
- Self-hosted, multi-Git (GitHub/GitLab/Gitee), multi-tenant, SSO/RBAC, BYOK
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 (→ GPL-2.0-or-later on 2030-02-28).