### PR TITLE
Add Agent Cost Guardrails to Developer Productivity Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ## Developer Productivity Tools
 
+- **[Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails)** – Framework-native budget limits and circuit breakers for AI agent frameworks (CrewAI, AutoGen, LangGraph). Hard token caps, cost alerts, and spend tracking with hooks that integrate directly into agent execution loops. Open-source, available on [PyPI](https://pypi.org/project/agent-cost-guardrails/) and [npm](https://npmjs.com/package/agent-cost-guardrails).
 - **[Raycast AI](https://raycast.com/ai)** – AI-powered productivity launcher with coding capabilities and workflow automation.
 - **[Warp AI](https://warp.dev/ai)** – AI-enhanced terminal with intelligent command suggestions.
 - **[Context7](https://context7.com/)** – MCP server providing up-to-date library documentation to LLMs and AI editors.


### PR DESCRIPTION
## Addition: Agent Cost Guardrails

Adding [Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails) to the **Developer Productivity Tools** section.

**What it does:** Framework-native budget limits and circuit breakers for AI agent frameworks — CrewAI, AutoGen, and LangGraph. Provides hard token caps, cost alerts, and spend tracking with hooks that integrate directly into agent execution loops.

**Why it fits:** Runaway AI agent costs are one of the top pain points for developers building multi-agent systems (90% of agentic apps fail within 30 days, cost blowups are a primary cause). This is the only OSS library offering framework-native enforcement with hard caps.

**Links:**
- GitHub: https://github.com/sapph1re/agent-cost-guardrails
- PyPI: https://pypi.org/project/agent-cost-guardrails/
- npm: https://npmjs.com/package/agent-cost-guardrails

**License:** MIT (open-source)