### PR TITLE
Add Agent Shadow Brain and Omni Skills Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[SwarmClaw](https://github.com/swarmclawai/swarmclaw)** – Self-hosted multi-agent runtime with MCP client and server support, 23+ LLM providers, persistent memory, skills, schedules, and messaging connectors. Electron desktop app, CLI, and Docker.
 - **[AgentsMesh](https://agentsmesh.ai)** – Self-hostable AI Agent Workforce Platform. Orchestrates Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode across remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, channels-based multi-agent collaboration, built-in Kanban, and per-pod MCP server. Multi-Git (GitHub/GitLab/Gitee), multi-tenant, SSO/RBAC, BYOK.
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
+- **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 
 ---
 
@@ -313,6 +314,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[LiteLLM](https://github.com/BerriAI/litellm)** – Unified API proxy for 100+ LLM providers with load balancing, spend tracking, and rate limiting.
 - **[OpenRouter](https://openrouter.ai/)** – Unified API gateway for accessing models from OpenAI, Anthropic, Google, Meta, and more.
 - **[Promptfoo](https://github.com/promptfoo/promptfoo)** – Open-source tool for testing, evaluating, and red-teaming LLM prompts and applications.
+- **[Omni Skills Forge](https://github.com/theihtisham/omni-skills-forge)** – Skill and command manager for AI assistants with dynamic loading and execution.
 
 ---
 


### PR DESCRIPTION
Hi! Adding two open-source AI developer tools:

- **Agent Shadow Brain** — AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews. ([GitHub](https://github.com/theihtisham/agent-shadow-brain) · [npm](https://www.npmjs.com/package/@theihtisham/agent-shadow-brain))

- **Omni Skills Forge** — Skill and command manager for AI assistants with dynamic loading and execution. ([GitHub](https://github.com/theihtisham/omni-skills-forge) · [npm](https://www.npmjs.com/package/omni-skills-forge))

Added to the Coding Agents and AI Frameworks and SDKs sections respectively, matching the existing format. Thanks!