### PR TITLE
Add Murmure to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs](https://aidevboard.com)** – AI job board aggregating 6,000+ positions from 340+ companies like OpenAI, Anthropic, and Google DeepMind. Free API and MCP server for AI-powered job search.
 - **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.
+- **[Murmure — AI DevTools Community Sentiment Tracker](https://github.com/murmurecc/ai-devtools-sentiment)** – Weekly sentiment analysis of AI developer tools (Cursor, Windsurf, Linear, Devin, etc.) based on Reddit, HN, GitHub Issues, and Discord.
 
 ---
 


### PR DESCRIPTION
Adds Murmure to the end of `README.md` > `Developer Productivity Tools`, per the contribution guidelines.

Entry:
- Name: Murmure — AI DevTools Community Sentiment Tracker
- URL: https://github.com/murmurecc/ai-devtools-sentiment
- Description: Weekly sentiment analysis of AI developer tools (Cursor, Windsurf, Linear, Devin, etc.) based on Reddit, HN, GitHub Issues, and Discord.

Murmure helps developer-tool teams track public sentiment, feature requests, and complaints across Reddit, Hacker News, GitHub Issues, and Discord.