### PR TITLE
Add unslop to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
+- **[unslop](https://github.com/MohamedAbdallah-14/unslop)** – CLI and MCP server (Claude Code plugin) that removes named AI writing patterns from text. Targets tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode and five intensity levels. Useful for cleaning commit messages, PR descriptions, and documentation drafts.
+
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
 
 ---


### PR DESCRIPTION
## Add unslop to Developer Productivity Tools

**Tool:** [unslop](https://github.com/MohamedAbdallah-14/unslop)

A CLI tool and MCP server (Claude Code plugin) that removes named AI writing patterns from text. Useful for developers who want to clean up AI-generated commit messages, PR descriptions, documentation drafts, and code comments before they ship.

**What it removes**
- Tricolons: "fast, reliable, and scalable"
- Em-dash overuse
- Hedging stacks: "it might potentially be worth considering"
- Sycophancy openers: "Great question!"
- Overused vocabulary: "delve", "crucial", "leverage"

**Why it fits Developer Productivity Tools**

The list already includes tools like toprank (Claude Code plugin), Context7 (MCP server), and codachi (Claude Code workflow tool). Unslop fits the same category: a Claude Code plugin that improves developer output quality.

**Usage**

```bash
cat commit_draft.md | unslop --stdin > clean.md
```

Lint mode (no writes):
```bash
unslop --stdin --audit < pr_description.txt
```

**Details**
- MIT licensed, public repository
- Five intensity levels
- Available as MCP server (Claude Code plugin) and standalone CLI
