### PR TITLE
feat: add KubeStellar Console to DevOps and Infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Infracost](https://www.infracost.io/)** – Cloud cost estimation in pull requests for Terraform/Pulumi.
 - **[Jenkins X](https://jenkins-x.io/)** – Cloud-native CI/CD with AI-enhanced automation.
 - **[DeployRamp](https://www.deployramp.com)** – AI-powered feature flagging platform that can automatically wrap PRs in feature flags.
+- **[KubeStellar Console](https://github.com/kubestellar/console)** – Open-source multi-cluster Kubernetes dashboard with an MCP server (kc-agent) enabling AI coding agents to query and manage clusters via natural language.
 
 ---
 


### PR DESCRIPTION
## What is this?

[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard with an integrated MCP server (`kc-agent`) for AI-assisted cluster operations.

## Why it belongs in DevOps and Infrastructure

KubeStellar Console enables AI coding agents (Claude Code, Copilot, Codex) to query and manage Kubernetes clusters via natural language through its MCP server:
- Multi-cluster observability across edge and cloud clusters.
- AI-powered operations: workload placement, policy enforcement, incident response.
- Integrations with 20+ CNCF projects (Argo CD, Kyverno, Istio, Prometheus).
- CNCF Sandbox project.

Added at the bottom of the DevOps and Infrastructure section, matching the existing format.