### PR TITLE
Add prompt-to-asset MCP server to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** – MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Zero API key required for first run via free tiers. `npm install -g prompt-to-asset`.
 
 ---
 


### PR DESCRIPTION
Adds prompt-to-asset to the MCP Servers and Directories section.

**prompt-to-asset** — MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models (Flux, SDXL, Ideogram, Recraft, and others). Zero API key required for first run via free tiers. MIT-licensed, installable via `npm install -g prompt-to-asset`.