### PR TITLE
Add Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
+- **[Agent Sessions](https://github.com/jazzyalex/agent-sessions)** – Local-first macOS app for searching, browsing, and resuming AI coding sessions across Codex CLI, Claude Code, Cursor CLI, Gemini CLI, GitHub Copilot CLI, OpenCode, Hermes, and OpenClaw.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
 


### PR DESCRIPTION
## Summary

Adds Agent Sessions to the Developer Productivity Tools section.

## Checklist

- [x] I have read the contribution guidelines
- [x] The tool is AI-related and useful for developers
- [x] I have added a short, clear description of the tool
- [x] The link is not a duplicate of an existing one
- [x] The title of the link is properly capitalized
- [x] The link follows the Awesome List format
- [x] My change does not include unrelated files or changes

## Why is this tool awesome?

Agent Sessions helps developers search, browse, and resume local AI coding sessions across Codex CLI, Claude Code, Cursor CLI, Gemini CLI, GitHub Copilot CLI, OpenCode, Hermes, and OpenClaw. It is useful when work is spread across multiple coding agents and old transcript context needs to be recovered locally.

## Link

https://github.com/jazzyalex/agent-sessions

## Additional context

The app is local-first and focused on session history, transcript search, and resume workflows.