### PR TITLE
Add cc-cost to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
+- **[cc-cost](https://github.com/lob-labs/cc-cost)** – Single-file Python CLI that parses Claude Code transcript JSONL and reports cost, prompt-cache hit rate, tool-call distribution, top expensive turns, and actionable optimization recommendations (`--diagnose`).
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
 


### PR DESCRIPTION
Adds [cc-cost](https://github.com/lob-labs/cc-cost) — a single-file Python CLI that parses Claude Code transcript JSONL and reports cost, cache hit rate, tool-call distribution, top expensive turns, and actionable optimization recommendations (`--diagnose`).

Fits the **Developer Productivity Tools** section alongside Burnd, CodeCosts, and Agent Cost Guardrails — same niche.

- Repo: https://github.com/lob-labs/cc-cost
- License: MIT
- Single-file, no third-party deps, Python 3.9+
- `pipx install git+https://github.com/lob-labs/cc-cost.git`

Thanks for maintaining this list!