### PR TITLE
Add MartinLoop to developer productivity tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 ## Developer Productivity Tools
 
 - **[Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails)** – Framework-native budget limits and circuit breakers for AI agent frameworks (CrewAI, AutoGen, LangGraph). Hard token caps, cost alerts, and spend tracking with hooks that integrate directly into agent execution loops. Open-source, available on [PyPI](https://pypi.org/project/agent-cost-guardrails/) and [npm](https://npmjs.com/package/agent-cost-guardrails).
+- **[MartinLoop](https://github.com/Keesan12/Martin-Loop)** – Open-source governed runtime for Claude Code, Codex, and Ralph-style autonomous AI coding workflows. Adds hard budget caps, max iteration limits, verifier gates, rollback evidence, explicit stop reasons, and JSONL run records.
 - **[Raycast AI](https://raycast.com/ai)** – AI-powered productivity launcher with coding capabilities and workflow automation.
 - **[Warp AI](https://warp.dev/ai)** – AI-enhanced terminal with intelligent command suggestions.
 - **[Context7](https://context7.com/)** – MCP server providing up-to-date library documentation to LLMs and AI editors.


### PR DESCRIPTION
Adds MartinLoop to Developer Productivity Tools.

MartinLoop is an open-source governed runtime for Claude Code, Codex, and Ralph-style autonomous AI coding workflows.

It adds:

- hard budget caps
- max iteration limits
- verifier gates
- rollback evidence
- explicit stop reasons
- JSONL run records

I placed it under Developer Productivity Tools because the section already includes Agent Cost Guardrails, and MartinLoop is also focused on budget/control/governance for AI agent workflows but more comprehensive.

Happy to adjust wording or placement if there is a better fit.