### PR TITLE
Add Septim Agents Pack to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
 - **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)** – AI-powered coding toolbar for any web app. Injects a floating toolbar via reverse proxy, captures element context, previews diffs, and applies approved changes in real time.
+- **[Septim Agents Pack](https://septimlabs.com/tools/agents?utm_source=awesome-ai-coding-tools&utm_medium=awesome-list&utm_campaign=oss-backlink)** – 10 named Claude Code sub-agents covering planning, architecture, brand, marketing, finance, design, legal, customer research, and cross-lane coordination. Drop the `.claude/agents/` folder into any project; pay-once at $49.
 
 ---
 


### PR DESCRIPTION
## What this adds

**[Septim Agents Pack](https://septimlabs.com/tools/agents?utm_source=awesome-ai-coding-tools&utm_medium=awesome-list&utm_campaign=oss-backlink)** — 10 named Claude Code sub-agents (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip), each covering a distinct function: planning, architecture, brand, marketing, finance, design, legal, customer, research, and cross-agent coordination.

## Why it fits this list

The Coding Agents section covers tools where AI plays an active coding/execution role. Septim Agents Pack is a pack of Claude Code sub-agents invoked from the Claude Code CLI — each agent is a `.md` file dropped into `.claude/agents/` that specialises Claude's behaviour for a specific domain. They are AI coding agents in the exact sense that Claude Code CLI tools on this list are.

## Format check

- Added to end of Coding Agents section
- Format matches existing entries: `**[Name](URL)** – description.`
- No emojis, no marketing claims
- UTM params on URL for attribution tracking

## Live product page

https://septimlabs.com/tools/agents