### PR TITLE
Add Claudex (open-source MCP memory + search for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[Claudex](https://github.com/kunwar-shah/claudex)** – Open-source MCP server giving Claude Code persistent memory and FTS5 full-text search across conversation history.
 
 ---
 


### PR DESCRIPTION
## What
Adds **Claudex** to the **MCP Servers and Directories** section.

## Entry
- **[Claudex](https://github.com/kunwar-shah/claudex)** – Open-source MCP server giving Claude Code persistent memory and FTS5 full-text search across conversation history.

## Why it fits
- AI-powered, developer-focused, publicly accessible
- Free and open-source (MIT licensed)
- Documented: https://github.com/kunwar-shah/claudex
- Install: `npm install -g @kunwarshah/claudex`

## Checklist
- [x] Added to the end of the relevant section (MCP Servers and Directories)
- [x] Uses the exact `- **[Tool Name](URL)** – Description.` format from CONTRIBUTING.md
- [x] Tool is AI-powered and useful to developers
- [x] Publicly accessible with a free tier (fully open source)
- [x] Has clear documentation and use case