### PR TITLE
Add agentwatch to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
+- **[agentwatch](https://github.com/mishanefedov/agentwatch)** – Local-only TUI + web dashboard observing every AI coding agent on your machine (Claude Code, Codex, Gemini CLI, Cursor, Hermes, OpenClaw) on one unified timeline. Per-turn token + cost accounting with cache-hit weighting, MAD z-score anomaly detection, context compaction visualizer, hybrid semantic search, MCP server mode, and OpenTelemetry exporter. No cloud, no telemetry. Free and MIT.
 
 ---
 


### PR DESCRIPTION
## Summary

agentwatch is a local-only TUI + web dashboard that observes every AI coding agent running on your laptop (Claude Code, Codex, Gemini CLI, Cursor, Hermes, OpenClaw) on one unified timeline. Built for operators running 2+ agents in parallel who currently piece spend, file changes, and shell commands together from five different JSONL files.

## What it does
- Per-turn token + cost accounting with cache-hit weighting (naive summers are 3–10x wrong without it)
- MAD z-score anomaly detection on cost / duration / tokens, period-1-to-4 stuck-loop detector
- Context compaction visualizer + hybrid semantic search (bge-small + FTS5 + RRF)
- MCP server mode exposing 5 stdio tools so agents can query their own history
- OpenTelemetry exporter using `gen_ai.*` semantic conventions

## Why it fits this list
- AI-powered / AI-enhanced ✓ (operates on AI agent session data)
- Useful to developers ✓ (multi-agent operators are the target user)
- Publicly accessible with free tier ✓ (MIT, no paid tier)
- Documented ✓ ([README](https://github.com/mishanefedov/agentwatch#readme))

Appended to **Developer Productivity Tools** per CONTRIBUTING. No cloud, no telemetry, no sign-in. macOS + Linux.

Repo: https://github.com/mishanefedov/agentwatch
npm: https://www.npmjs.com/package/@misha_misha/agentwatch