### PR TITLE
Add Crab Code to CLI Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[Crab Code](https://github.com/crabforge/crab-code)** – Rust-native agentic coding CLI supporting any LLM provider with multi-entry-point architecture (CLI/IDE/Web/Desktop). Apache-2.0.
 
 ---
 


### PR DESCRIPTION
Add [Crab Code](https://github.com/crabforge/crab-code) to the CLI Tools section. Rust-native agentic coding CLI supporting any LLM provider, Apache-2.0.