### PR TITLE
Add AgentPlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
+- **[AgentPlane](https://github.com/basilisk-labs/agentplane)** – Local-first, Git-native CLI harness for repo-local coding-agent work, recording task state, accepted plans, verification evidence, and finish records inside the repository.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Adds AgentPlane to `Developer Productivity Tools`.

Disclosure: I maintain AgentPlane.

AgentPlane is not another coding agent. It is a local-first, Git-native CLI harness for repo-local coding-agent work, with task state, accepted plans, verification evidence, and finish records written inside the repository.

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the existing README list format
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

AgentPlane gives teams using coding agents an auditable workflow record in Git instead of relying only on chat/session context. It is useful for developers who want explicit task state, plan acceptance, verification notes, and closure evidence around AI-assisted code changes.

## 🔗 Link

https://github.com/basilisk-labs/agentplane

## 📝 Additional context

Suggested category: `Developer Productivity Tools`, because AgentPlane is workflow infrastructure around coding-agent work rather than an agent or model framework.

Verification:

- `git diff --check`
