### PR TITLE
Add Instafill.ai MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[Instafill.ai](https://instafill.ai)** – MCP server for AI-powered PDF form filling. Auto-completes any PDF form by extracting fields and filling them from saved profiles, uploaded files, or supplied data.
 
 ---
 


### PR DESCRIPTION
Adding [Instafill.ai](https://instafill.ai) under **MCP Servers and Directories**.

Instafill.ai ships an MCP server that exposes AI-powered PDF form filling as a tool for AI coding agents. Auto-completes any PDF form by extracting fields and filling them from saved profiles, uploaded files, or supplied data — useful when an agent's workflow needs to produce a filled PDF (intake forms, contracts, applications).