### PR TITLE
Add Claude Skills to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
 - **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)** – AI-powered coding toolbar for any web app. Injects a floating toolbar via reverse proxy, captures element context, previews diffs, and applies approved changes in real time.
+- **[Claude Skills](https://github.com/heymegabyte/claude-skills)** – 14-category autonomous product-building OS bundling 18 specialized agents (architect, test-writer, deploy-verifier, security-reviewer, visual-qa, performance-profiler, accessibility-auditor, content-writer, completeness-checker, dependency-auditor, migration-agent, incident-responder, computer-use-operator, meta-orchestrator, seo-auditor, cost-estimator, changelog-generator, code-simplifier). One config drops into Claude Code, Codex, Cursor, Copilot, Gemini CLI, Windsurf, opencode, Cline, and Aider. One-line prompts deploy production sites with hard quality gates (Playwright at 6 breakpoints, axe-core 0 violations, Lighthouse a11y >=95, AI vision >=8/10).
 
 ---
 


### PR DESCRIPTION
Adds **[Claude Skills](https://github.com/heymegabyte/claude-skills)** to the **Coding Agents** section.

### What it is
14-category autonomous product-building OS that bundles 18 specialized agents (architect, test-writer, deploy-verifier, security-reviewer, visual-qa, performance-profiler, accessibility-auditor, content-writer, completeness-checker, dependency-auditor, migration-agent, incident-responder, computer-use-operator, meta-orchestrator, seo-auditor, cost-estimator, changelog-generator, code-simplifier) and orchestrates them in parallel.

### Cross-tool
Single config drops into Claude Code, Codex, Cursor, Copilot, Gemini CLI, Windsurf, opencode, Cline, Aider — write once, run everywhere.

### Hard quality gates
- Playwright E2E at 6 breakpoints
- axe-core 0 violations
- Lighthouse a11y >=95
- AI vision QA >=8/10
- Yoast GREEN
- Zero TODOs / stubs / dead code

### Checklist
- [x] One product per PR
- [x] Correct section (Coding Agents — multi-agent orchestration)
- [x] Description matches existing entry style (1-2 sentences, includes key capability)