### PR TITLE
Add AgentsMesh CLI to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[AgentsMesh](https://github.com/sampleXbro/agentsmesh)** - CLI that syncs canonical skills, rules, and config across Claude Code, Cursor, Copilot, and 10+ AI coding tools from a single `.agentsmesh/` directory.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

AgentsMesh lets you define skills, rules, commands, agents, MCP servers, hooks, and ignore patterns once in .agentsmesh/ and generate native config for Claude Code and 12 other AI coding tools.

- Links rebasing in MD files
- Team collaboration 
- Plugin support

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

It a reliable canonical source for AI coding agent rules, commands, skills, MCP, hooks, and permissions — synced across AI coding assistants.

## 🔗 Link

https://github.com/sampleXbro/agentsmesh

## 📝 Additional context

- Open source, MIT license
- Actively maintained
- No SaaS dependencies, no paid requirements
- npm: npx agentsmesh generate - single command to keep your configs up to date