### PR TITLE
Add oh-my-kimi: multi-agent orchestration for Kimi K2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[oh-my-kimi](https://github.com/dmae97/oh-my-kimi)** – Multi-agent orchestration harness for Kimi K2.6. Parallel coding teams in git worktrees, DAG scheduling, live quality gates, terminal HUD, and MCP skill-hooks.
 
 ---
 


### PR DESCRIPTION
## oh-my-kimi

Multi-agent orchestration harness for the Kimi Code CLI (K2.6).

**Why it fits:** CLI Tools section — oh-my-kimi is a terminal-native tool that wraps Kimi Code CLI with parallel agent teams, git worktree isolation, DAG scheduling, live quality gates, and a terminal HUD.

**Key features:**
- Parallel coding agents in isolated git worktrees
- DAG scheduler with retry, skip-on-failure, and fallback roles
- Live quality gates (lint, typecheck, test, build)
- Terminal HUD and cockpit dashboard (tmux)
- MCP skill-hooks and local graph memory
- 234 tests, CI green, v1.1.0 stable

**Links:**
- GitHub: https://github.com/dmae97/oh-my-kimi
- npm: https://www.npmjs.com/package/@oh-my-kimi/cli
- Stars: 49 | Forks: 2 | License: Apache-2.0