### PR TITLE
Add SeekLink to code search and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Pieces.app](https://pieces.app/)** – AI-powered code snippet management, search, and sharing.
 - **[16x Prompt](https://prompt.16x.engineer/)** – AI tool for enhanced code context and prompt-based navigation.
 - **[codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill)** – AI coding agent skill that analyzes git history to reveal hotspots, bug magnets, bus factor risks, and development momentum before reading any code.
+- **[SeekLink](https://github.com/simonsysun/seeklink)** – Local semantic search CLI for Markdown/Obsidian vaults, combining BM25, vectors, wikilinks, headings, and JSON line-anchored output for coding agents.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Adds SeekLink to the Code Search and Navigation section.

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

SeekLink gives AI coding agents a local, private retrieval layer for Markdown and Obsidian-compatible vaults. It combines BM25, vector retrieval, wikilinks, headings, and aliases, then returns line-anchored text or JSON output that agents can use through ordinary subprocess calls.

This is useful when a project keeps specs, notes, decisions, or llm-wiki-style documentation in Markdown and an agent needs precise context without sending the vault to a hosted search service.

## 🔗 Link

https://github.com/simonsysun/seeklink

## 📝 Additional context

Added entry:

```md
- **[SeekLink](https://github.com/simonsysun/seeklink)** – Local semantic search CLI for Markdown/Obsidian vaults, combining BM25, vectors, wikilinks, headings, and JSON line-anchored output for coding agents.
```


