### PR TITLE
Add Agentprobe — agentic commerce readiness scorer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Claude MCP Servers](https://www.claudemcp.com/servers)** – Claude's curated MCP server list.
 - **[MCPServers.Net](https://mcpservers.net/)** – Comprehensive MCP navigation with tutorials and resources.
 - **[MCP Market](https://mcpmarket.com/)** – Marketplace for MCP tools and services.
+- **[Agentprobe](https://agentprobe.fly.dev/)** – Free agentic commerce readiness scorer. Probes any URL across 13 signals (llms.txt, OpenAPI spec, MCP endpoint, catalog API, quote API, checkout, payment rails, fulfillment proof) and returns a 0–110 score with a CERTIFIED badge. MCP server available at /mcp.
 
 ---
 


### PR DESCRIPTION
## What this adds

**[Agentprobe](https://agentprobe.fly.dev/)** — free agentic commerce readiness scorer. Probes any seller URL across 13 signals and returns a 0–110 score with grade tiers (NOT_READY / PARTIAL / AGENT_READY / CERTIFIED).

## Probes covered

- llms.txt, OpenAPI spec, ai-plugin.json, MCP endpoint
- Machine-readable catalog, quote endpoint, checkout handoff
- Payment rail declarations, unsupported-rail handling
- Refund/contact metadata, fulfillment proof
- No-fake-claims verification

## Why it fits the MCP Servers and Directories section

Agentprobe ships an MCP server at `/mcp` (JSON-RPC 2.0) with a `probe_site(url)` tool. It belongs next to the existing MCP directories because it tells developers whether a seller site is ready to be called by AI agents — a readiness check rather than a server registry.

## Links

- Tool: https://agentprobe.fly.dev/
- MCP: https://agentprobe.fly.dev/mcp
- OpenAPI: https://agentprobe.fly.dev/openapi.yaml
- Badge example: https://agentprobe.fly.dev/badge/agentprobe.fly.dev.svg