### PR TITLE
Add Claude Code Skills Chinese directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,4 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Awesome AI Agents](https://github.com/aylar-ghezelbash/awesome-ai-agents)** – AI agents for automation and development.
 - **[Altern](https://altern.ai)** – AI tool discovery platform.
 - **[DevTools Directory](https://devtools.directory)** – Directory of trending dev tools.
+- **[Claude Code Skills 中文精选集](https://claude-skills.bt199.com/)** – Chinese curated directory of Claude Code Skills, agents, plugins, and workflow resources.


### PR DESCRIPTION
## Summary
- Adds a Chinese Claude Code Skills directory to Related Lists.
- The site curates Claude Code Skills, agents, plugins, and workflow resources for Chinese-speaking developers.

## Checklist
- [x] The entry is a tool/resource that helps developers discover AI coding workflows
- [x] The description is clear and matches the existing Related Lists style
- [x] Link tested: https://claude-skills.bt199.com/