### PR TITLE
Add Nimbalyst to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Roo Code](https://roocode.com/)** – Popular open-source VS Code extension (fork of Cline) with multi-model support and autonomous coding modes.
 - **[Qoder](https://qoder.com/)** – Agentic coding platform focused on deeper reasoning.
 - **[Aide](https://aide.dev/)** – Open-source AI-native IDE with proactive agents, built on top of VS Code.
+- **[Nimbalyst](https://nimbalyst.com)** – Open-source visual workspace for building with Codex, Claude Code. Visual editor. Session and task manager.
+
+## GitHub or website?
+
+**Use the website (nimbalyst.com).** The Aide example you gave links to `aide.dev`, not their repo, so the list's convention is product homepage. Two more reasons:
+
+- The website handles non-dev visitors (downloads, screenshots, pricing). GitHub drops them straight into a code tree.
+- "Open-source" status can be conveyed in the description; the link itself should optimize for the conversion most readers want.
+
+Use the GitHub URL only when the list explicitly prefers repos (e.g., MCP server registries, awesome-electron, sindresorhus-style lists). For generalist AI tool lists, website wins.
+
+Heads-up: those duplicate `URL:` lines have grown to four per entry now. Looks like every save is appending another. Worth a quick manual cleanup or letting me dedupe in one pass when you want.
 
 ---
 


### PR DESCRIPTION
Add Nimbalyst to Code Editors and Assistants. Visual workspace

## 🚀 Summary

Adding Nimbalyst to the Code Editors and Assistants

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x ] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

Nimbalyst is an open source visual workspace to work better with Claude Code, Codex, Opencode:
- Agents edit the same files you do, in visual editors for markdown, mockups, diagrams, data models, and code
- Agent changes show up as red/green diffs with per-block accept/reject
- Sessions, files, and tasks are linked, so you can trace work across them
- Parallel sessions are managed on a kanban board instead of buried in terminal tabs
- Tasks live in the same workspace as the agent, so plans, bugs, and work stay linked to sessions and files
- Developer workflow features like worktrees, workstreams, visual git management, and agent git proposals

## 🔗 Link

https://nimbalyst.com

## 📝 Additional context

Thanks for making this list and for considering adding Nimbalyst


