### PR TITLE
docs(readme): add lucinate to CLI Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[lucinate](https://github.com/lucinate-ai/lucinate)** – Terminal-native TUI chat client for AI agents. Connects to OpenClaw gateways, Hermes agent profiles, and any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenAI). Features streaming responses, markdown rendering, tool call cards, local skills, cron management, and multi-agent support. Cross-platform with Homebrew tap.
 
 ---
 


### PR DESCRIPTION
Add [lucinate](https://github.com/lucinate-ai/lucinate) — a terminal-native TUI chat client written in Go for interacting with AI agents.

lucinate connects to OpenClaw gateways, Hermes agent profiles, and any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenAI). It provides streaming responses, markdown rendering, tool call cards, local skills, cron management, session browsing, and multi-agent support — all from the terminal.

**Section:** CLI Tools
**Public signal:** Active GitHub development, Homebrew tap, cross-platform install scripts, website at lucinate.ai, MIT licensed