### PR TITLE
Add ejentum-mcp under MCP Servers and Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ## MCP Servers and Directories
 
+- **[ejentum-mcp](https://github.com/ejentum/ejentum-mcp)** – Reasoning Harness for agentic AI: 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, catching sycophancy, hallucination, and reasoning decay before they emerge.
 - **[MCP Server Finder](https://www.mcpserverfinder.com/servers)** – Discover and browse MCP servers.
 - **[PulseMCP](https://www.pulsemcp.com/servers)** – Large, frequently updated directory of MCP servers.
 - **[MCP.so](https://mcp.so/)** – Platform for MCP server resources and community.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ## MCP Servers and Directories
 
-- **[ejentum-mcp](https://github.com/ejentum/ejentum-mcp)** – Reasoning Harness for agentic AI: 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, catching sycophancy, hallucination, and reasoning decay before they emerge.
+- **[ejentum-mcp](https://github.com/ejentum/ejentum-mcp)** – MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
 - **[MCP Server Finder](https://www.mcpserverfinder.com/servers)** – Discover and browse MCP servers.
 - **[PulseMCP](https://www.pulsemcp.com/servers)** – Large, frequently updated directory of MCP servers.
 - **[MCP.so](https://mcp.so/)** – Platform for MCP server resources and community.


### PR DESCRIPTION
Adds `ejentum/ejentum-mcp` to the MCP servers section.

MCP server (npm `ejentum-mcp` for stdio, or remote HTTPS at `https://api.ejentum.com/mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained
- One line added, alphabetical placement verified
- Not a duplicate

Maintainer is me; happy to address review feedback.