### PR TITLE
Add Awesome AI Startups to Related Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,4 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Awesome AI Agents](https://github.com/aylar-ghezelbash/awesome-ai-agents)** – AI agents for automation and development.
 - **[Altern](https://altern.ai)** – AI tool discovery platform.
 - **[DevTools Directory](https://devtools.directory)** – Directory of trending dev tools.
+- **[Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups)** – A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **Related Lists** section.

It's a curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — covering 18 categories (AI Agents, Coding, Marketing, Audio/Voice, Image/Design, etc.) with ~440 entries.

Followed contributing conventions: matched the section's existing entry format and added at the bottom of the section.