### PR TITLE
Add agent-lsp to MCP Servers and Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[agent-lsp](https://github.com/blackwell-systems/agent-lsp)** – MCP server that gives AI coding agents language server intelligence (go-to-definition, find-references, diagnostics, refactoring, speculative execution) across 30 languages. 56 tools, 22 agent skills, single Go binary.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [agent-lsp](https://github.com/blackwell-systems/agent-lsp) to the MCP Servers and Directories section.
- agent-lsp is an MCP server that gives AI coding agents language server intelligence (go-to-definition, find-references, diagnostics, refactoring, speculative execution) across 30 languages. 56 tools, 22 agent skills, single Go binary.

## Checklist

- [x] Added to end of relevant section
- [x] Follows existing entry format
- [x] Tool is publicly accessible with a free tier (open-source, MIT license)
- [x] Well-documented with clear use case