### PR TITLE
Add great_cto to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
 - **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)** – AI-powered coding toolbar for any web app. Injects a floating toolbar via reverse proxy, captures element context, previews diffs, and applies approved changes in real time.
+- **[great_cto](https://github.com/avelikiy/great_cto)** – Engineering management layer for 34 specialist AI agents covering the full SDLC (architect, pm, senior-dev, code-reviewer, qa, security, devops, l3-support + 18 archetype-specific reviewers). 25 archetypes auto-detected with compliance gates (PCI-DSS, HIPAA, FedRAMP, GDPR, EU AI Act). Multi-platform — Claude Code, Cursor, Codex CLI, Aider, Continue. Local kanban board, OWASP LLM Top 10 scanner, MIT.
 
 ---
 


### PR DESCRIPTION
Adding [great_cto](https://github.com/avelikiy/great_cto) to **Coding Agents**.

### What it is
Engineering management layer for **34 specialist AI agents** running the full SDLC pipeline — architect, pm, senior-dev, code-reviewer, qa-engineer, security-officer, devops, l3-support, plus 18 archetype-specific reviewers (PCI, oracle/web3, gov-public, edtech, mlops, fintech, etc).

### Key features
- **25 archetypes auto-detected** from `package.json` / `pyproject.toml` / `Cargo.toml` — compliance gates (PCI-DSS, HIPAA, FedRAMP, GDPR, EU AI Act, COPPA) attached automatically
- **Multi-platform** — runs identically in Claude Code, Cursor, Codex CLI, Aider, Continue (via AGENTS.md + MCP)
- **Local kanban board** (`great-cto board`) — see all agent activity, gates, costs in one screen
- **Built-in OWASP LLM Top 10 scanner** — `great-cto scan ./` with SARIF for GitHub Code Scanning
- **MIT** licensed, no SaaS, no telemetry

v2.7.0 shipped May 2026 · MIT

Happy to adjust placement or wording — thanks for maintaining this list!