### PR TITLE
Add Aura IDE to AI tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
 - **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)** – AI-powered coding toolbar for any web app. Injects a floating toolbar via reverse proxy, captures element context, previews diffs, and applies approved changes in real time.
-
+- **[Aura](https://github.com/CarpseDeam/Aura-IDE)** – Desktop AI orchestration IDE with a Planner/Worker dual-agent system, multi-provider AI, diff approval, and local-first privacy.
+  
 ---
 
 ## CLI Tools


### PR DESCRIPTION
🚀 Summary:
Add Aura to the Coding Agents section- a desktop AI orchestration IDE featuring a Planner/Worker dual agent system, multi provider support, diff approval, and local first privacy.

✅ Checklist:

I have read the contribution guidelines

The tool is AI-related and useful for developers

I have added a short, clear description of the tool

The link is not a duplicate of an existing one

The title of the link is properly capitalized

The link follows the Awesome List format

My change does not include unrelated files or changes

📌 Why is this tool awesome?
Aura's Planner/Worker architecture offers a unique approach to AI-driven coding: the Planner reads code and writes a technical specification, then hands it off to the Worker to apply edits with diff approval. This is not just autocomplete or in-editor chat — it's a full pair-programming model with safety controls (backups, sandboxed terminal, read-only mode). It also supports five providers (DeepSeek, OpenAI, Anthropic, Google Gemini, OpenRouter) and runs fully locally with no telemetry.

🔗 Link:
https://github.com/CarpseDeam/Aura-IDE

📝 Additional context:
Stable release v1.0.1 is available. Cross-platform (Windows, macOS, Linux) via PySide6. The README includes screenshots, installation instructions, API key setup, and an architecture diagram.