### PR TITLE
feat: add llm-prices to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Git AI](https://github.com/acunniffe/git-ai)** – Git extension that tracks AI-generated code and the prompts behind each line.
 - **[Perplexity Pro](https://perplexity.ai/pro)** – AI search engine with real-time web access for coding solutions.
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.
+- **[llm-prices](https://github.com/benbencodes/llm-prices)** – Zero-dependency Python CLI and library for comparing LLM API pricing across 21 providers (123+ models). Query pricing, calculate costs, find the cheapest option for a given token budget. Install: `pip install git+https://github.com/benbencodes/llm-prices.git` or `brew install benbencodes/tap/llm-prices`. Open-source, MIT license.
 - **[Supercode.sh](https://supercode.sh/)** – Cursor extension adding Architect Mode, voice input, and prompt enhancement.
 - **[toprank](https://github.com/nowork-studio/toprank)** – Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic, ship meta tag and schema markup fixes, and manage ad campaigns directly from Claude Code.
 - **[Google Drive – Memyard](https://github.com/zagmoai/public-google-drive)** – Agent skill that lets AI coding agents create and edit Google Docs and Sheets without sign-in. Documents hosted on Memyard with shareable links.


### PR DESCRIPTION
## What this adds

**[llm-prices](https://github.com/benbencodes/llm-prices)** — a zero-dependency Python CLI and library for comparing LLM API pricing.

### Why it belongs here

The Developer Productivity Tools section already includes cost-related tools (Agent Cost Guardrails, CodeCosts, Burnd). llm-prices complements these from a different angle: it's a **CLI-first, queryable pricing database** that helps developers:

- Pick the cheapest model for a given task (`llm-prices top 5 --in 50000 --out 5000`)
- Calculate exact costs before committing to a provider  
- Compare prices across 21 providers (123 models) in one command

### Quick demo

```bash
pip install git+https://github.com/benbencodes/llm-prices.git

# Find cheapest models for a 100k input, 5k output workload
llm-prices top 5 --in 100000 --out 5000

# Compare specific models
llm-prices compare gpt-4o claude-sonnet-4-6 gemini-2.5-flash --in 10000 --out 2000

# Show all providers with min pricing
llm-prices providers
```

### Details

- **123 models** across **21 providers** (OpenAI, Anthropic, Google, Mistral, Groq, DeepSeek, xAI, Moonshot, Hyperbolic, and more)
- Zero runtime dependencies (pure Python stdlib)
- MIT license
- Also installable via Homebrew: `brew install benbencodes/tap/llm-prices`
