### PR TITLE
Add ctop — AI coding agent session monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[ctop](https://github.com/aakashadesara/ctop)** – htop for AI coding agents. Monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [ctop](https://github.com/aakashadesara/ctop) to the **CLI Tools** section.

ctop is htop for AI coding agents — monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js.

- **Homepage**: https://aakashadesara.github.io/ctop/
- **Only README.md was modified** (one bullet point added to the CLI Tools section)