### PR TITLE
Add OTF to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Screenshot-to-Code](https://github.com/abi/screenshot-to-code)** – Convert screenshots and designs into clean HTML/React/Vue code using AI.
 - **[Forge](https://forge-web.rebaselabs.online)** – BYOK full-stack app creator — use your own API key (Anthropic, OpenAI, Google) with no markup. Multi-stage pipeline generates production-ready Next.js apps from natural language.
 - **[MeterCall](https://metercall.ai)** – Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
+- **[OTF](https://otf-kit.dev)** – Production full-stack kits (Next.js + Expo) that ship with battle-tested CLAUDE.md, .cursorrules, and 40+ tested prompts so Claude Code, Cursor, and Lovable extend the codebase like docs instead of guessing. Free MIT SDK + commercial kits.
 
 ---
 


### PR DESCRIPTION
OTF gives builders production full-stack kits (Next.js + Expo) instead of generating apps inside sandboxes. Every kit ships with battle-tested `CLAUDE.md`, `.cursorrules`, and 40+ tested prompts in `ai/prompts/` so Claude Code, Cursor, and Lovable can extend the codebase like docs.

Free MIT SDK · Live demos at https://saas.otf-kit.dev and https://fitness-preview.otf-kit.dev · Marketing at https://otf-kit.dev.

Fits the App Builders section as the "file-system agent" complement to the sandboxed builders (Bolt, Lovable, Replit) already listed there.