### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
+- **[OpenQuack](https://github.com/larryxiao/openquack)** – Local voice dictation menu bar app for macOS that pairs with Cursor, Claude Code, Codex, and Aider; long contextual prompts via WhisperKit on Apple Silicon, pastes at the cursor, all on-device.
 
 ---
 


### PR DESCRIPTION
Adds OpenQuack to **Developer Productivity Tools**.

OpenQuack is an MIT-licensed local voice dictation menu-bar app for macOS. It pairs with AI coding tools (Cursor, Claude Code, Codex, Aider) — press a hotkey, dictate a long contextual prompt that would be slow to type, and OpenQuack pastes the transcript at your cursor. All on-device via WhisperKit on Apple Silicon; no cloud, no subscription.

Precedent in this list: `Supercode.sh` (voice input for Cursor). OpenQuack is a separately-installed companion that works with any AI editor, not a specific extension.

Repo: https://github.com/larryxiao/openquack
Appended at the end of Developer Productivity Tools.

Thanks for maintaining the list.