### PR TITLE
Add OTF — AI-native full-stack template ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Screenshot-to-Code](https://github.com/abi/screenshot-to-code)** – Convert screenshots and designs into clean HTML/React/Vue code using AI.
 - **[Forge](https://forge-web.rebaselabs.online)** – BYOK full-stack app creator — use your own API key (Anthropic, OpenAI, Google) with no markup. Multi-stage pipeline generates production-ready Next.js apps from natural language.
 - **[MeterCall](https://metercall.ai)** – Universal API gateway over 10M+ APIs with AI router across 25+ models. Type a sentence in plain English, get a working app. 727+ ready-made modules to fork. Free tier, usage-based pricing.
+- **[OTF — Open Template Forest](https://otf-kit.dev)** – Production-ready full-stack kits (Next.js, Expo) pre-wired for Claude Code, Cursor, and Lovable, with tested prompt libraries and AI configs included. MIT SDK + commercial kits.
 
 ---
 


### PR DESCRIPTION
Adds OTF — Open Template Forest (https://otf-kit.dev) under App Builders.

OTF is a template ecosystem built explicitly for AI-coding-tool users: production-ready full-stack kits (Next.js, Expo) that ship with `CLAUDE.md`, `.cursorrules`, `lovable.md`, and a per-kit library of 20+ tested prompts. The thesis is that sandbox builders (Lovable/Bolt) can spin up an MVP, but file-system agents (Claude Code, Cursor) are what take you to production — and OTF kits are the context those agents need.

Why it fits this list: every other entry in App Builders helps users generate code. OTF is the production-ready substrate those generated apps converge on, with AI configs baked in.

Live demo: https://saas.otf-kit.dev
Landing: https://otf-kit.dev
Docs: https://otf-kit.dev/docs

Happy to move to a different section if App Builders isn't the right home.

— Dave