### PR TITLE
Add APort to AI coding security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Endor Labs](https://www.endorlabs.com/ai-code-security-review)** – AI code review for security risks and architectural vulnerabilities.
 - **[Code Intelligence CI Fuzz](https://www.code-intelligence.com/)** – AI-automated fuzz testing for C/C++.
 - **[Vulert](https://vulert.com/)** – Detects vulnerabilities in open-source dependencies without accessing your code.
+- **[APort](https://aport.io)** – Agent identity and policy enforcement for AI-agent tool calls, with [guardrail integration examples](https://github.com/aporthq/aport-integrations) for adding pre-action authorization.
 
 ---
 


### PR DESCRIPTION
## ?? Summary

Adds APort to the Security section as an AI-agent security tool for identity, policy enforcement, and pre-action authorization around tool calls.

## ? Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) - description`)
- [x] My change does not include unrelated files or changes

## ?? Why is this tool awesome?

APort gives developers building AI coding agents a way to enforce identity and policy checks before agent tool calls, which complements the security section's focus on developer-facing security tooling.

## ?? Link

https://aport.io

## ?? Additional context

Also references the public guardrail integration examples repository: https://github.com/aporthq/aport-integrations

Validation:
- Verified https://aport.io returns HTTP 200
- Verified https://github.com/aporthq/aport-integrations returns HTTP 200
- Ran `git diff --check`