### PR TITLE
feat: add Mneme HQ to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Google Drive – Memyard](https://github.com/zagmoai/public-google-drive)** – Agent skill that lets AI coding agents create and edit Google Docs and Sheets without sign-in. Documents hosted on Memyard with shareable links.
 - **[MemClaw](https://memclaw.me)** – Persistent project memory for AI coding agents (MCP-compatible). Creates isolated memory workspaces per project with a web dashboard to review and manage context. Free and open source.
 - **[git-parsec](https://github.com/erishforG/git-parsec)** – Git worktree lifecycle manager that gives each AI agent an isolated workspace tied to issue tickets (Jira, GitHub Issues, GitLab), avoiding index.lock conflicts in parallel workflows.
+- **[Mneme HQ](https://github.com/TheoV823/mneme)** – Enforce architectural decisions on every AI coding assistant call. Deterministic retrieval and pre-flight governance for Claude Code, Cursor, and agent workflows.
 - **[AI Dev Jobs](https://aidevboard.com)** – AI job board aggregating 6,000+ positions from 340+ companies like OpenAI, Anthropic, and Google DeepMind. Free API and MCP server for AI-powered job search.
 - **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.


### PR DESCRIPTION
## What's being added

**[Mneme HQ](https://github.com/TheoV823/mneme)** — architectural governance layer for AI-assisted development.

Added to the **Developer Productivity Tools** section, after `git-parsec`.

## Why it fits

Mneme HQ enforces project-level architectural decisions on every AI coding assistant call. It:

- Deterministically retrieves relevant decisions from a structured `project_memory.json`
- Injects a compact context packet into the LLM system prompt before generation
- Detects constraint and anti-pattern violations in generated output
- Works with Claude Code, Cursor, Cline, and agent frameworks

It prevents architectural drift during AI-assisted development — the model is told what was already decided, rather than deriving it from scratch on each call.

## Details

- **Repo**: https://github.com/TheoV823/mneme
- **License**: MIT
- **Language**: Python (pip-installable, no heavy dependencies)
- **Status**: Active (Layer 1 frozen with a reproducible benchmark suite)