### PR TITLE
Add Blueprint to Developer Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
+- **[Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint)** – Open-source planning copilot for coding agents. Asks multiple-choice questions about your task, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.
 
 ---
 


### PR DESCRIPTION
## Summary

Adding [Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint) to the **Developer Productivity Tools** section. Blueprint is an open-source planning copilot for coding agents. It asks multiple-choice questions about your task, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is AI-related and useful for developers
- [x] I have added a short, clear description of the tool
- [x] The link is not a duplicate of an existing one
- [x] The title of the link is properly capitalized
- [x] The link follows the Awesome List format (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## Why it should be included

Blueprint splits the work of planning between the agent and the user. The agent enumerates considerations and choices; the user makes decisions. This keeps the user in control while avoiding the tedious work of thinking through every detail upfront.

Questions are presented in rounds of approximately five at a time, progressing from high-level to low-level. Answering a few questions is a small, manageable chunk of work, and the user repeats until they decide to stop. This works whether you want a quick plan or an extensive one. The output is a markdown plan any coding agent can execute.

## Link

- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint
- GitHub (for Cursor and Windsurf): https://github.com/imbue-ai/blueprint-vscode