### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[CronAI](https://cronai-nu.vercel.app/)** – Convert plain English schedule descriptions to cron expressions with AI. Supports standard and extended formats. Free, no signup.
 - **[JSONFix](https://jsonfix-lake.vercel.app/)** – AI-powered JSON fixer that instantly repairs broken JSON with missing quotes, trailing commas, or unescaped characters. Free, no signup.
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
+- **[Agent FM](https://github.com/agentfm-ai/agent-fm)** – Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix, blocker alerts, and BYOK narration.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
 


### PR DESCRIPTION
## 🚀 Summary

Adds Agent FM to Developer Productivity Tools.

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

Agent FM is useful for developers running multiple Claude Code and Codex sessions because it surfaces progress, blockers, errors, and attention requests as live narration instead of requiring them to monitor every terminal.

## 🔗 Link

https://github.com/agentfm-ai/agent-fm

## 📝 Additional context

Agent FM is local, open source, macOS-first, and uses bring-your-own-key narration.
