### PR TITLE
Add AgentTier to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Codex Infinity](https://codex-infinity.com)** – Autonomous coding agent that runs continuously on bare metal VPS. Run your Claude Max or OpenAI Codex plans with full root access and no cloud timeouts.
 - **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** – AI background code analysis agent that watches your codebase and provides real-time insights, suggestions, and automated reviews.
 - **[OpenMagic](https://github.com/Kalmuraee/OpenMagic)** – AI-powered coding toolbar for any web app. Injects a floating toolbar via reverse proxy, captures element context, previews diffs, and applies approved changes in real time.
+- **[AgentTier](https://github.com/agenttier/agenttier)** – Self-hosted Kubernetes-native sandbox runtime for AI coding agents (Claude Code, OpenHands, LangGraph). Same Sandbox CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation, hierarchical governance, and a streaming SSE invoke API.
 
 ---
 


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `## Coding Agents`.

AgentTier is a self-hosted Kubernetes-native sandbox runtime for AI coding agents. The same `Sandbox` CRD provisions a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation, per-session ServiceAccount, hierarchical (cluster → namespace) governance policies, and a streaming agent-mode REST API (`POST /configure` to install agent code, then SSE-streaming `POST /invoke` to run it). Reference templates ship for Claude Code + AWS Bedrock, OpenHands, and a model-free LangGraph agent. Apache-2.0.

It sits next to **brood-box**, **AgentsMesh**, and **SwarmClaw** — the other multi-runtime, self-hostable platforms already in the Coding Agents section — but takes a different shape: Kubernetes operator (CRD + controller-runtime) instead of microVM/Electron desktop app. That makes it a fit for teams that already run Kubernetes and want an opinionated agent runtime without standing up new infrastructure.

**Compliance with CONTRIBUTING.md:**

- ✅ AI-powered: hosts AI coding agents.
- ✅ Useful to developers: provides isolated sandboxes per agent and per developer.
- ✅ Publicly accessible with a free tier: Apache-2.0, fully self-hostable.
- ✅ Well-documented: full mkdocs site at https://agenttier.github.io/agenttier/, README, examples, RELEASING guide, SECURITY guide.
- ✅ Format `- **[Tool Name](url)** – Description.` matched.
- ✅ Added at the end of the **Coding Agents** section.

Disclosure: I'm a contributor to AgentTier.
