### PR TITLE
Add Pluribus to CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[Pluribus](https://github.com/caioribeiroclw-pixel/pluribus)** – Open-source CLI that keeps one versioned AI coding context in sync across Claude Code, Cursor, Copilot, OpenClaw, Windsurf, Continue, and Zed.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Adds Pluribus to the CLI Tools section. Pluribus is an open-source CLI for keeping one versioned AI coding context in sync across Claude Code, Cursor, Copilot, OpenClaw, Windsurf, Continue, and Zed.

## ✅ Checklist

- [x] I have read the contribution guidelines
- [x] The tool is AI-related and useful for developers
- [x] I have added a short, clear description of the tool
- [x] The link is not a duplicate of an existing one
- [x] The title of the link is properly capitalized
- [x] The link follows the Awesome List format
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

Most AI coding tools keep their own instruction/context files. Pluribus helps developers maintain one source of truth and audit/sync the generated files those tools expect, reducing context drift across multi-tool workflows.

## 🔗 Link

https://github.com/caioribeiroclw-pixel/pluribus

## 📝 Additional context

Package: https://www.npmjs.com/package/pluribus-context
