### PR TITLE
Add pluginpool to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[pluginpool](https://github.com/mturac/pluginpool)** – Ten focused Claude Code plugins for everyday developer productivity (commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge). Each plugin's core is a deterministic Python helper (stdlib only) usable as a plain CLI without Claude Code. 89 hermetic tests, MIT.
 
 ---
 


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) to *CLI Tools*.

Ten focused Claude Code plugins for everyday developer productivity, each one a deterministic Python helper usable as a plain CLI without Claude Code:

- **commit-narrator** — semantic commit message from staged diff
- **pr-storyteller** — PR title + body + test plan from commits and diff vs base
- **test-gap** — lines in diff lacking test coverage
- **deps-doctor** — multi-ecosystem dependency audit (npm, pip, cargo, go)
- **env-lint** — `.env` vs `.env.example` key parity
- **secret-guard** — pre-commit secret scanner
- **standup-gen** — daily standup notes from git activity
- **todo-harvest** — TODO/FIXME/HACK scan with git blame
- **flaky-detector** — per-test flakiness % from N runs
- **changelog-forge** — conventional commits → CHANGELOG + semver

89 hermetic tests, Python stdlib only at runtime, MIT. Each tool can be run directly as a CLI or invoked as a Claude Code slash command.