### PR TITLE
Add Inference Labs to AI Coding Frameworks & Toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Haystack](https://haystack.deepset.ai/)** – Open-source framework for building production-ready LLM applications, RAG pipelines, and agents.
 - **[LiteLLM](https://github.com/BerriAI/litellm)** – Unified API proxy for 100+ LLM providers with load balancing, spend tracking, and rate limiting.
 - **[OpenRouter](https://openrouter.ai/)** – Unified API gateway for accessing models from OpenAI, Anthropic, Google, Meta, and more.
+- **[Inference Labs](https://inference-labs.com)** - Vendor-neutral routing + evaluation layer across OpenAI/Azure, Anthropic, Google, and AWS Bedrock. Policy-based model selection (cost/quality/latency), semantic cache, trace logging, and JSONL eval/SFT exports. Open pricing API + OSS Python SDK.
 - **[Promptfoo](https://github.com/promptfoo/promptfoo)** – Open-source tool for testing, evaluating, and red-teaming LLM prompts and applications.
 - **[Omni Skills Forge](https://github.com/theihtisham/omni-skills-forge)** – Skill and command manager for AI assistants with dynamic loading and execution.
 


### PR DESCRIPTION
Hi! Proposing a one-line addition near OpenRouter/LiteLLM in **AI Coding Frameworks & Toolkits**.

[Inference Labs](https://inference-labs.com) is a vendor-neutral routing/evaluation layer for production AI apps:

- Multi-provider routing across OpenAI/Azure, Anthropic, Google, Bedrock
- Policy-based selection (cost-first / quality-first / latency-first)
- Semantic cache + trace logging + JSONL eval/SFT exports
- Open pricing API and OSS Python SDK (Apache-2.0)

Happy to adjust wording or move placement if you'd prefer.