### PR TITLE
Add brooks-lint to Code Review and Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review)** - AI-powered GitHub Pull Request code review using MiniMax models.
 - **[VibeDoctor](https://vibedoctor.io/)** – AI code health scanner for vibe-coded apps. Detects hallucinated imports, phantom packages, and security issues that traditional scanners miss with MCP Support.
 - **[Relay](https://github.com/momobits/Relay/)** – Persistent memory for AI coding workflows. Give AI coding agents memory of what was built, what broke, and what's next.
+- **[brooks-lint](https://github.com/hyhmrright/brooks-lint)** – Claude Code plugin that reviews code against twelve classic engineering books, citing each finding to its source and scoring codebase health 0–100.
 
 ---
 


### PR DESCRIPTION
Adds **[brooks-lint](https://github.com/hyhmrright/brooks-lint)** to the *Code Review and Refactoring* section.

brooks-lint is an open-source, AI-powered code-review plugin (Claude Code / Gemini CLI / Codex CLI / GitHub Action) that reviews code against twelve classic software-engineering books, cites each finding to its source, and scores codebase health 0–100. It is publicly accessible and free (MIT). Entry follows the CONTRIBUTING format (`- **[Name](url)** – desc.`) and is appended to the end of the relevant section.