### PR TITLE
Add HagiCode to Code Editors and Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Roo Code](https://roocode.com/)** – Popular open-source VS Code extension (fork of Cline) with multi-model support and autonomous coding modes.
 - **[Qoder](https://qoder.com/)** – Agentic coding platform focused on deeper reasoning.
 - **[Aide](https://aide.dev/)** – Open-source AI-native IDE with proactive agents, built on top of VS Code.
+- **[HagiCode](https://hagicode.com/)** – AI coding workspace with proposal-driven workflows, multi-agent execution, multi-repository coordination, and integrated commit and knowledge tools.
 
 ---
 


### PR DESCRIPTION
## Summary\n- add HagiCode to the Code Editors and Assistants section\n- describe it as a proposal-driven AI coding workspace with multi-agent execution and multi-repo coordination\n\n## Why here\nHagiCode is positioned as a full AI coding workspace rather than a single CLI, so the editors/assistants section is the closest fit.