### PR TITLE
Add Curio MCP (design-style library for AI) to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[Curio MCP](https://designbycurio.com/mcp)** – Design-style library for AI: search hundreds of real design styles and fetch token-complete, machine-readable specs (colors, typography, spacing, components) to apply to sites, decks, and products. OAuth sign-in, free tier included. [Documentation](https://designbycurio.com/docs).
 
 ---
 


### PR DESCRIPTION
Adds **Curio MCP** to the MCP Servers and Directories section.

Curio is a design-style library for AI: hundreds of real design styles (movements, brands, cultural traditions) packaged as token-complete, machine-readable specs. The remote MCP server (`https://mcp.designbycurio.com/mcp`, HTTP transport, OAuth sign-in, free tier) lets coding agents search styles and fetch full design specs to apply to sites, decks, and products.

- Site: https://designbycurio.com
- Docs (per-client setup: Claude, Cursor, VS Code, ChatGPT, Codex): https://designbycurio.com/docs
- Listed in the official MCP Registry as `com.designbycurio/curio`
- Public repo: https://github.com/voltwake/curio-mcp-extension

Found this repo via the Contribute page at aifordevelopers.org, which builds from this list.