### PR TITLE
Add Superhighway to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[AI Dev Jobs MCP](https://aidevboard.com/mcp)** – Search 5,400+ AI developer jobs with salary data via MCP. REST API also available.
 - **[Not Human Search](https://nothumansearch.ai/mcp)** – Agent-first search engine for discovering AI tools, MCP servers, and APIs.
 - **[CLIRank](https://clirank.dev/)** – API directory scoring 387 APIs on agent-friendliness across 11 signals. MCP server and web directory.
+- **[Superhighway](https://superhighway.walls.sh)** – Web search API for AI coding agents — live search, news, images, scrape, and deep research via MCP. Free API key or pay per call via x402/USDC. Install: `npx -y superhighway-mcp`.
 
 ---
 


### PR DESCRIPTION
**[Superhighway](https://superhighway.walls.sh)** is a web search API built specifically for AI coding agents — live web search, news, images, page scrape, and one-call deep research.

**Why it belongs in MCP Servers:**
- Installs in one line: `npx -y superhighway-mcp` (published on npm as `superhighway-mcp`)
- 5 MCP tools: `search`, `news`, `images`, `scrape`, `research`
- Free API key (no signup) or pay per call via x402/USDC on Base — no human in the loop
- Used alongside Not Human Search already listed here

**Format follows contribution guide** (bold name, em-dash description, end of section).