### PR TITLE
Add Sipcode to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[Sipcode](https://github.com/Anuj7411/sipcode)** – Open source MIT CLI for Anthropic Claude Code. Caps verbose terminal tool output (git, npm, grep, ls, cat, find, tsc), dedups duplicate file reads within a session via a PreToolUse hook, and surfaces per-session cost stats via 15 MCP tools. 1,317 tests, zero network calls.
 
 ---
 


### PR DESCRIPTION
Adds Sipcode to the CLI Tools section.

Sipcode is an open source MIT CLI for Claude Code (Anthropic's terminal coding agent). It runs as a PreToolUse hook to cap verbose tool output before bytes reach the model, dedups same-session re-reads of unchanged files, and exposes 15 MCP tools so Claude can read its own context-hygiene stats.

Locked benchmark (reproducible): 62.6% median tool-output savings on a 20-task corpus, range 37.4% to 80.6%.

How it differs from neighbors in this section:
- codachi monitors the context window (read-only); Sipcode actively reduces it via the hook.
- agx focuses on durable execution loops; Sipcode focuses on what the model reads each turn.

Free, publicly accessible, well-documented:
- Repo: https://github.com/Anuj7411/sipcode
- Docs: https://anuj7411.github.io/sipcode
- Install: npm i -g sipcode && sipcode init

Eligibility checklist:
- [x] AI-powered / AI-enhanced developer tool
- [x] Publicly accessible with free tier (open source, MIT)
- [x] Well-documented (README, dedicated docs site, MCP setup guide)
- [x] Format matches existing entries (bold link, en-dash, period)
- [x] Appended at end of CLI Tools section