### PR TITLE
Add Cynative to security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Endor Labs](https://www.endorlabs.com/ai-code-security-review)** – AI code review for security risks and architectural vulnerabilities.
 - **[Code Intelligence CI Fuzz](https://www.code-intelligence.com/)** – AI-automated fuzz testing for C/C++.
 - **[Vulert](https://vulert.com/)** – Detects vulnerabilities in open-source dependencies without accessing your code.
-- **[Cynative](https://github.com/cynative/cynative)** - Open sourvce agentic security CLI that runs code in a built-in sandbox to research source, cloud and runtime. Read-only enforced by default.
+- **[Cynative](https://github.com/cynative/cynative)** - Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Endor Labs](https://www.endorlabs.com/ai-code-security-review)** – AI code review for security risks and architectural vulnerabilities.
 - **[Code Intelligence CI Fuzz](https://www.code-intelligence.com/)** – AI-automated fuzz testing for C/C++.
 - **[Vulert](https://vulert.com/)** – Detects vulnerabilities in open-source dependencies without accessing your code.
+- **[Cynative](https://github.com/cynative/cynative)** - Open sourvce agentic security CLI that runs code in a built-in sandbox to research source, cloud and runtime. Read-only enforced by default.
+
 
 ---
 


### PR DESCRIPTION
Added Cynative to the list of security tools in the README.

## 🚀 Summary
Adds Cynative, an open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).

## ✅ Checklist
- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?
cynative is an agentic CLI that writes and runs its own code in a built-in sandbox to investigate security across a developer's cloud, code and runtime. It's read-only enforced by default — write actions are gated behind an action gate and credential downscoping rather than left to a system prompt — so it's safe to point at real environments. Open source, bring-your-own-model and a single Go binary.

## 🔗 Link
https://github.com/cynative/cynative

## 📝 Additional context
Open source, BYOM (bring-your-own-model), runs entirely in the user's own environment. Connectors: AWS, GCP, Azure, Kubernetes, GitHub, GitLab.