### PR TITLE
Add AI Delivery Spec - product-side SDD framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ## Developer Productivity Tools
 
+- [AI Delivery Spec](https://github.com/franklinxkk/ai-delivery-spec) - Product-side SDD framework bridging product truth and AI coding agent handoff: prototype-interaction ledgers, FRR completion gates, AC-YAML, and delivery manifests.
 - **[Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails)** – Framework-native budget limits and circuit breakers for AI agent frameworks (CrewAI, AutoGen, LangGraph). Hard token caps, cost alerts, and spend tracking with hooks that integrate directly into agent execution loops. Open-source, available on [PyPI](https://pypi.org/project/agent-cost-guardrails/) and [npm](https://npmjs.com/package/agent-cost-guardrails).
 - **[Raycast AI](https://raycast.com/ai)** – AI-powered productivity launcher with coding capabilities and workflow automation.
 - **[Warp AI](https://warp.dev/ai)** – AI-enhanced terminal with intelligent command suggestions.


### PR DESCRIPTION
# AI Delivery Spec (v4.9.14)

## 一句话
面向产品经理的 SDD 规范框架：把想法/原型/竞品变成可读 PRD + 可执行 AI Coding 契约。

## 版本演进 (v4.9.9 → v4.9.14)
- **v4.9.10**: 加固多模块交付门禁（multi-module delivery gates）
- **v4.9.11**: Release 版本
- **v4.9.13**: 强化验证与领域路由（harden validation and domain routing）
- **v4.9.14**: 清理推广视频 artifact，精简仓库

## 核心能力
- **多智能体生命周期验证**：6 领域 × 7 阶段 × 5 reviewer agent = 210 验证单元
- **P0 FRR 防线**：RFI/Ledger/薄 FRR/Completion Ledger 四类阻断
- **三条工作路径**：传统研发全生命周期 / AI Native 产品发现 / AI Coding 自动编码
- **PRD 三档**：轻量 / Human-First Full PRD / AI-Coding Full PRD
- **6 个内置领域模块**：traffic / CRM / AI+Data / AI Native / education / medical
- **验证脚本 10+**：CLI 聚合 `ai_delivery_spec_cli.py check`

## 兼容平台
OpenClaw / Claude Code / Cursor / Codex / Copilot Workspace

## 安装
```bash
npx skills add franklinxkk/ai-delivery-spec
```

GitHub: https://github.com/franklinxkk/ai-delivery-spec
Gitee: https://gitee.com/engourdi/ai-delivery-spec