### PR TITLE
Add BuyWhere MCP to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ---
 
+- **[BuyWhere MCP](https://buywhere.ai)** – AI-powered shopping agent that finds the best prices across 100M+ real merchant products. MCP server for integration with AI coding assistants like Claude and Cursor.
+
 ## Related Lists
 
 - **[AI For Developers](https://aifordevelopers.org)** – Curated directory of AI dev tools.


### PR DESCRIPTION
BuyWhere is an AI-powered shopping agent that finds the best prices across 100M+ real merchant products. The MCP server enables integration with AI coding assistants like Claude and Cursor for price comparison and shopping assistance.

- Website: https://buywhere.ai
- GitHub: https://github.com/BuyWhere/buywhere-mcp