### PR TITLE
docs: add Skill Hub to Related Lists section

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,4 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Awesome AI Agents](https://github.com/aylar-ghezelbash/awesome-ai-agents)** – AI agents for automation and development.
 - **[Altern](https://altern.ai)** – AI tool discovery platform.
 - **[DevTools Directory](https://devtools.directory)** – Directory of trending dev tools.
+- **[Skill Hub](https://skill.442595.xyz/)** – Open-source AI Agent Skills directory with 2,595+ skills across 10+ categories (OpenAI Codex, Claude, Hermes, OpenCode, OpenClaw). [GitHub](https://github.com/rdone4425/skill)


### PR DESCRIPTION
## Add Skill Hub to Related Lists

**Skill Hub** is an open-source AI Agent Skills directory covering 2,595+ skills across 10+ categories.

### Why add Skill Hub?
- Multi-platform coverage: OpenAI Codex, Claude, Hermes, OpenCode, OpenClaw
- 2,595+ curated skills from 23+ community sources
- Open-source, actively maintained
- Useful resource for AI coding tools ecosystem

### Entry added
- **[Skill Hub](https://skill.442595.xyz/)** – AI Agent Skills navigator with 2,595+ skills. [GitHub](https://github.com/rdone4425/skill)

---
Submitted by @rdone4425 | CC0 license