### PR TITLE
Add Data Olympus

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Context7](https://context7.com/)** – MCP server providing up-to-date library documentation to LLMs and AI editors.
 - **[Task Master](https://github.com/eyaltoledano/claude-task-master)** – AI-driven task management for development with Claude, designed for Cursor.
 - **[SpecStory](https://specstory.com/)** – Cursor/VS Code/Claude Code extension for summarizing and sharing AI chat context.
-- **[Data Olympus](https://github.com/knaisoma/data-olympus)** - Governed project knowledge for AI coding agents via MCP. Agents can propose learnings, humans promote accepted guidance, and retrieval filters out expired or superseded rules before they enter future coding sessions.
+- **[Data Olympus](https://github.com/knaisoma/data-olympus)** – Governed project knowledge for AI coding agents via MCP. Agents can propose learnings, humans promote accepted guidance, and retrieval filters out expired or superseded rules before they enter future coding sessions.
 - **[Git AI](https://github.com/acunniffe/git-ai)** – Git extension that tracks AI-generated code and the prompts behind each line.
 - **[Perplexity Pro](https://perplexity.ai/pro)** – AI search engine with real-time web access for coding solutions.
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Context7](https://context7.com/)** – MCP server providing up-to-date library documentation to LLMs and AI editors.
 - **[Task Master](https://github.com/eyaltoledano/claude-task-master)** – AI-driven task management for development with Claude, designed for Cursor.
 - **[SpecStory](https://specstory.com/)** – Cursor/VS Code/Claude Code extension for summarizing and sharing AI chat context.
+- **[Data Olympus](https://github.com/knaisoma/data-olympus)** - Governed project knowledge for AI coding agents via MCP. Agents can propose learnings, humans promote accepted guidance, and retrieval filters out expired or superseded rules before they enter future coding sessions.
 - **[Git AI](https://github.com/acunniffe/git-ai)** – Git extension that tracks AI-generated code and the prompts behind each line.
 - **[Perplexity Pro](https://perplexity.ai/pro)** – AI search engine with real-time web access for coding solutions.
 - **[CodeCosts](https://codecosts.pages.dev/)** – Compare pricing across AI coding tools with an interactive calculator.


### PR DESCRIPTION
## 🚀 Summary

Adds Data Olympus to the Developer Productivity Tools section as an MCP-backed governed project-knowledge layer for AI coding agents.

## ✅ Checklist

- [x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [x] The tool is **AI-related and useful for developers**
- [x] I have **added a short, clear description** of the tool
- [x] The link is not a **duplicate** of an existing one
- [x] The title of the link is **properly capitalized**
- [x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

Data Olympus helps coding agents reuse accepted project knowledge across sessions without treating every remembered note as authoritative. Agents can propose learnings, humans promote accepted guidance, and retrieval filters out expired or superseded rules before they enter future coding sessions.

## 🔗 Link

https://github.com/knaisoma/data-olympus

## 📝 Additional context

The v0.4.0 governance release added validity windows, supersession-aware retrieval, and in-force filtering.