### PR TITLE
Add patina

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[patina](https://github.com/devswha/patina)** – Multilingual CLI and agent skill that audits and rewrites AI-sounding writing patterns while preserving claims, numbers, polarity, and causation.
 
 ---
 


### PR DESCRIPTION
I maintain patina and would like to add it to this list.

patina fits the CLI Tools section because it is an MIT-licensed Node CLI and agent skill for auditing and rewriting multilingual AI-sounding writing patterns while preserving claims, numbers, polarity, and causation.

---
Note: this resubmits #435, which was auto-closed on 2026-06-21 when its source fork was deleted in an account cleanup — it was not closed by review. The entry itself is unchanged.