### PR TITLE
Add UIZZE UI context for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Burnd](https://github.com/garvitsurana/burnd)** – Local-first CLI (`npx getburnd`) that parses your `.claude/projects/*.jsonl` session files to find cost leaks in Claude Code usage — retry storms, tool overuse, repeated reads, long bash output, tired-coding hours. Runs entirely offline. Free core + optional Pro detectors.
 
 - **[Qovery Deploy Skill](https://github.com/Qovery/qovery-skills)** – AI Agent Skill that deploys any application to Kubernetes from Claude Code, Cursor, OpenCode, and 30+ AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`.
+- **[UIZZE](https://uizze.com/)** – UI context for coding agents: browse public Web and iOS references free, then use full-access MCP workflows for design contracts, implementation validation, audits, and critiques.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Adds UIZZE to Developer Productivity Tools as a UI-context workflow for coding agents.

## ✅ Checklist

- [x] I have read the contribution guidelines
- [x] The tool is AI-related and useful for developers
- [x] I have added a short, clear description of the tool
- [x] The link is not a duplicate of an existing one
- [x] The title of the link is properly capitalized
- [x] The link follows the Awesome List format
- [x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

UIZZE gives coding agents task-specific UI context instead of relying on generic visual defaults. Developers can browse the public Web and iOS reference catalog free; full access adds hosted MCP workflows for design contracts, implementation validation, audits, and critiques.

## 🔗 Link

https://uizze.com/

## 📝 Additional context

The description explicitly separates free public browsing from the full-access agent workflow.
