### PR TITLE
Add OpenAgentRelay to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Butterfish](https://butterfi.sh)** – AI tool for enhancing shell productivity with natural language.
 - **[codachi](https://github.com/vincent-k2026/codachi)** – Context window monitor for Claude Code that shows burn rate and time remaining, with an ASCII pet that reacts to your workflow.
 - **[agx](https://github.com/ramarlina/agx)** – Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume across sessions. Supports Claude Code, Codex, Gemini CLI, and Ollama.
+- **[OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay)** – Open-source CLI that exposes a restricted local Claude Code, Codex, or automation as a keyed trusted-LAN capability, with JSON output and meaningful exit codes for agent workflows.
 
 ---
 


### PR DESCRIPTION
## 🚀 Summary

Add OpenAgentRelay to the CLI Tools section as an open-source companion for Claude Code, Codex, and other command-line agents.

## ✅ Checklist

- [x] I have read the contribution guidelines
- [x] The tool is AI-related and useful for developers
- [x] I have added a short, clear description
- [x] The link is not a duplicate
- [x] The title is properly capitalized
- [x] The link follows the Awesome List format
- [x] The change includes no unrelated files

## 📌 Why is this tool awesome?

OpenAgentRelay lets a developer expose a restricted local coding agent or automation as a capability that a teammate, script, or another agent can invoke over a keyed trusted LAN. It provides machine-readable JSON, expected-agent validation, meaningful exit codes, and bounded conversations while keeping the publisher's source, prompts, dependencies, and credentials local.

The project is currently Alpha and its documentation explicitly limits use to trusted-LAN, non-production scenarios.

## 🔗 Link

https://github.com/ShakespeareLabs/open-agent-relay
