### PR TITLE
feat: Add Quay (Autonomous AI Software Factory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Pythagora](https://pythagora.ai/)** – AI agent that builds apps through conversational interaction.
 - **[Open Interpreter](https://github.com/OpenInterpreter/open-interpreter)** – Open-source agent that runs code locally in response to natural language, supporting Python, JS, shell, and more.
 - **[SWE-agent](https://github.com/princeton-nlp/SWE-agent)** – Princeton's autonomous agent that resolves real GitHub issues by navigating repos, editing files, and running tests.
+- **[Quay](https://github.com/Das-rebel/quay)** – Autonomous AI Software Factory with customizable agent pipelines, MCP integration, real-time Mission Control dashboard. Self-hosted, MIT license.
 - **[AutoGen](https://github.com/microsoft/autogen)** – Microsoft's multi-agent framework for building AI agent teams that collaborate on coding tasks.
 - **[CrewAI](https://www.crewai.com/)** – Multi-agent orchestration platform for building teams of AI agents for development and automation.
 - **[Copilot Workspace](https://githubnext.com/projects/copilot-workspace)** – GitHub's agent-powered dev environment that turns issues into code changes with plans, specs, and implementation.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 
 ## AI Frameworks and SDKs
 
+- **[A3M Router](https://github.com/Das-rebel/a3m-router)** – Open-source LLM router & AI gateway with parallel multi-LLM execution. 47+ providers, 62% cost savings, 99.5% routing accuracy, semantic cache, circuit breaker. 19.5 KB, zero ML dependencies. 
 - **[LangChain](https://www.langchain.com/)** – The most popular framework for building LLM-powered applications with chains, agents, and retrieval.
 - **[LlamaIndex](https://www.llamaindex.ai/)** – Data framework for connecting LLMs to external data sources with indexing and retrieval.
 - **[Vercel AI SDK](https://sdk.vercel.ai/)** – TypeScript toolkit for building AI-powered UIs with streaming, tool calling, and multi-provider support.


### PR DESCRIPTION
## Add Quay

**Quay** is an open-source Autonomous AI Software Factory:

- Role-based agents: Engineer → Reviewer → Security → Deployer
- Customizable pipeline stages
- MCP (Model Context Protocol) integration
- Real-time Mission Control dashboard with SSE
- SQLite-backed step tracking
- TypeScript/Svelte, MIT license

GitHub: https://github.com/Das-rebel/quay