### PR TITLE
Update README.md: Add Trent AI to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Refact.ai](https://refact.ai/)** – Open-source AI code completion and refactoring with self-hosting support.
 - **[Continue](https://continue.dev/)** – Open-source, pluggable AI code completion for VS Code and JetBrains.
 - **[Visual Studio IntelliCode](https://visualstudio.microsoft.com/services/intellicode/)** – Microsoft's AI code completion for Visual Studio.
-- **[Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/)** – Real-time AI code suggestions with security scanning. *(Now part of Amazon Q Developer)*
+- **[Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/)** – Real-time AI code suggestions with  scanning. *(Now part of Amazon Q Developer)*
 - **[CodeGeeX](https://codegeex.cn/)** – Open-source multilingual code generation model.
 - **[Supermaven](https://supermaven.com/)** – Ultra-fast completions with 1M token context window.
 
@@ -200,10 +200,10 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Sweep](https://github.com/sweepai/sweep)** – AI agent for automating PR reviews and fixes.
 - **[Greptile](https://greptile.com/code-review-bot)** – AI bot for in-depth code review and PR analysis.
 - **[What The Diff](https://whatthediff.ai/)** – AI tool for summarizing and analyzing code diffs.
-- **[DeepSource](https://deepsource.io/)** – Automated code review with tech debt tracking and security analysis.
+- **[DeepSource](https://deepsource.io/)** – Automated code review with tech debt tracking and  analysis.
 - **[Codacy](https://www.codacy.com/)** – Code quality platform with 30+ language support.
 - **[JetBrains Qodana](https://www.jetbrains.com/qodana/)** – AI-powered static analysis for code quality.
-- **[Semgrep](https://semgrep.dev/)** – Static analysis for finding bugs and security issues.
+- **[Semgrep](https://semgrep.dev/)** – Static analysis for finding bugs and  issues.
 - **[CodeQL (GitHub)](https://codeql.github.com/)** – Semantic code analysis for security and quality.
 - **[Snyk (DeepCode)](https://snyk.io/)** – Security-focused code analysis with vulnerability detection.
 - **[Pixee](https://pixee.ai)** – AI bot for security-focused PR reviews and automatic fixes.
@@ -369,6 +369,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[Endor Labs](https://www.endorlabs.com/ai-code-security-review)** – AI code review for security risks and architectural vulnerabilities.
 - **[Code Intelligence CI Fuzz](https://www.code-intelligence.com/)** – AI-automated fuzz testing for C/C++.
 - **[Vulert](https://vulert.com/)** – Detects vulnerabilities in open-source dependencies without accessing your code.
+- **[Trent Agentic AI security platform](https://trent.ai)** – Continuously assess AI agents, MCP servers, AI-native applications, and code shipped with AI coding tools; trace attack chains; and verify proposed fixes landed.
 
 ---
 


### PR DESCRIPTION
Adds Trent AI to Security. Free entry points: an open-source (Apache-2.0) agent-environment scanner and a free security assessment.
Disclosure: I work on Trent.

## 🚀 Summary

Adds Trent AI to the list. Trent is an agentic AI security platform for developers shipping code with AI coding tools: it runs inside MCP-compatible clients (Claude Code, Codex, Cursor, Lovable), continuously assesses the code and AI agents a team ships, traces attack chains, and verifies proposed fixes landed.

Disclosure: I work on Trent AI.

## ✅ Checklist

- [ x] I have read the [contribution guidelines](https://github.com/ai-for-developers/awesome-ai-coding-tools/blob/main/CONTRIBUTING.md)
- [ x] The tool is **AI-related and useful for developers**
- [ x] I have **added a short, clear description** of the tool
- [ x] The link is not a **duplicate** of an existing one
- [ x] The title of the link is **properly capitalized**
- [ x] The link follows the **Awesome List format** (`- [Tool Name](link) – description`)
- [ x] My change does not include unrelated files or changes

## 📌 Why is this tool awesome?

AI coding tools ship code faster than any security team can review it, and there were already about 80 developers for every security engineer before coding agents joined. Trent puts the security review inside the same tools developers already use: connect over MCP, get findings judged for real exploitability in your environment rather than generic severity scores, and get proposed fixes verified after they land. For OpenClaw users there is also trentclaw, an open-source security assessment skill installable self-serve from ClawHub.

## 🔗 Link
https://trent.ai

## 📝 Additional context

<!--
Optional: anything else we should know or consider?
-->

