### PR TITLE
Add UIZZE UI quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review)** - AI-powered GitHub Pull Request code review using MiniMax models.
 - **[VibeDoctor](https://vibedoctor.io/)** – AI code health scanner for vibe-coded apps. Detects hallucinated imports, phantom packages, and security issues that traditional scanners miss with MCP Support.
 - **[Relay](https://github.com/momobits/Relay/)** – Persistent memory for AI coding workflows. Give AI coding agents memory of what was built, what broke, and what's next.
+- **[UIZZE](https://uizze.com/)** – Checks changed web and iOS UI files for concrete finish risks such as generic placeholder styling, inconsistent spacing, and missing states; available as a GitHub Action, agent skill, and free MCP preview.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review)** - AI-powered GitHub Pull Request code review using MiniMax models.
 - **[VibeDoctor](https://vibedoctor.io/)** – AI code health scanner for vibe-coded apps. Detects hallucinated imports, phantom packages, and security issues that traditional scanners miss with MCP Support.
 - **[Relay](https://github.com/momobits/Relay/)** – Persistent memory for AI coding workflows. Give AI coding agents memory of what was built, what broke, and what's next.
-- **[UIZZE](https://uizze.com/)** – Checks changed web and iOS UI files for concrete finish risks such as generic placeholder styling, inconsistent spacing, and missing states; available as a GitHub Action, agent skill, and free MCP preview.
+- **[UIZZE](https://uizze.com/)** – Free anti-ui-slop Skill and deterministic preview for coding agents; full UIZZE adds live UI research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review)** - AI-powered GitHub Pull Request code review using MiniMax models.
 - **[VibeDoctor](https://vibedoctor.io/)** – AI code health scanner for vibe-coded apps. Detects hallucinated imports, phantom packages, and security issues that traditional scanners miss with MCP Support.
 - **[Relay](https://github.com/momobits/Relay/)** – Persistent memory for AI coding workflows. Give AI coding agents memory of what was built, what broke, and what's next.
-- **[UIZZE](https://uizze.com/)** – Stop generic UI before it ships. The free MIT `anti-ui-slop` Skill gives coding agents a product-specific design contract, required loading/empty/error states, and a hard finish gate. The optional full UIZZE workflow adds no-account preview checks, live search, validation, audits, and rendered critique across 800,000+ real web and iOS screens.
+- **[UIZZE](https://uizze.com/)** – Stop generic UI before it ships. The free MIT `anti-ui-slop` Skill gives coding agents a product-specific design contract, required loading/empty/error states, and a hard finish gate. The optional authenticated MCP provides `find_ui_references` and `find_ui_materials` over 800,000+ real web and iOS screens.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ A curated list of AI-powered coding tools: editors, agents, code completion, rev
 - **[MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review)** - AI-powered GitHub Pull Request code review using MiniMax models.
 - **[VibeDoctor](https://vibedoctor.io/)** – AI code health scanner for vibe-coded apps. Detects hallucinated imports, phantom packages, and security issues that traditional scanners miss with MCP Support.
 - **[Relay](https://github.com/momobits/Relay/)** – Persistent memory for AI coding workflows. Give AI coding agents memory of what was built, what broke, and what's next.
-- **[UIZZE](https://uizze.com/)** – Free anti-ui-slop Skill and deterministic preview for coding agents; full UIZZE adds live UI research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.
+- **[UIZZE](https://uizze.com/)** – Stop generic UI before it ships. The free MIT `anti-ui-slop` Skill gives coding agents a product-specific design contract, required loading/empty/error states, and a hard finish gate. The optional full UIZZE workflow adds no-account preview checks, live search, validation, audits, and rendered critique across 800,000+ real web and iOS screens.
 
 ---
 


### PR DESCRIPTION
## What does this PR add?

- Adds UIZZE to the Code Review and Refactoring section.
- Leads with the free MIT anti-ui-slop Skill.
- Keeps optional authenticated MCP access distinct, with focused UI references and hosted design materials grounded in 800,000+ real web and iOS screens.

## Why is it useful here?

UIZZE gives coding agents a product-specific design contract, required loading/empty/error states, and a hard finish gate for interface quality. It complements code review and refactoring tools with rendered UI quality checks.

- Product: https://uizze.com/
- Skill: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
- Install: `npx skills add https://uizze.com --skill anti-ui-slop`
- Optional authenticated MCP: https://uizze.com/mcp

## Verification

- Updated the visible README entry.
- Ran `git diff --check`.
- Kept the listing free-first and aligned with the canonical UIZZE repository.